### PR TITLE
fix downloader lib

### DIFF
--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -1,6 +1,6 @@
 'use strict';
 const fs = require('fs');
-const ytdl = require('@microlink/youtube-dl');
+const ytdl = require('ytdl-core');
 const options = require('../config');
 /**
  * This function downloads the given youtube video in best audio format as mp3 file

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "author": "Swapnil Soni",
   "license": "ISC",
   "dependencies": {
-    "@microlink/youtube-dl": "^1.13.2",
     "axios": "^0.18.0",
     "cheerio": "^1.0.0-rc.3",
     "meow": "^5.0.0",

--- a/util/get-link.js
+++ b/util/get-link.js
@@ -1,7 +1,7 @@
 'use strict';
+const { promisify } = require('util');
 const youtubeSearch = require('yt-search');
 
-const { promisify } = require('util');
 const search = promisify(youtubeSearch);
 
 /**

--- a/util/scrape.js
+++ b/util/scrape.js
@@ -26,4 +26,3 @@ const scrape = html => {
 };
 
 module.exports = scrape;
-


### PR DESCRIPTION
Hey sorry I forgot about updating downloader module,
I was actually testing the package you used `@microlink/youtube-dl` to see how it works,
when I changed back to prior code I forgot to update it.
In this case we are using `ytdl-core`(https://www.npmjs.com/package/ytdl-core) instead of earlier one

Can you test both of these? Your earlier code using `@microlink/youtube-dl` and newer version which is using `ytdl-core` to see which one downloads faster, we can then rewrite downloader library to use the prior or later one depending on results.