### PR TITLE
Fix ENOENT (unexpected recursive path)

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -152,6 +152,7 @@ if (!input[0]) {
         case 'album': {
           var cacheCounter = 0;
           songData = await spotifye.getAlbum(URL);
+          songData.name = songData.name.replace('/', '-');
           
           var dir = path.join((cli.flags.output != null) ? cli.flags.output : process.cwd(), songData.name);
 


### PR DESCRIPTION
ℹ Saving Album: /home/%username%/Music/Gold Cobra (Deluxe) - Limp Bizkit / Interscope
Something went wrong!
{ Error: ENOENT: no such file or directory, mkdir '/home/%username%/Music/Gold Cobra (Deluxe) - Limp Bizkit / Interscope'
at Object.mkdirSync (fs.js:773:3)
at Object.read (/home/%username%/workspace/spotify-dl/lib/cache.js:23:16)
at /home/%username%/workspace/spotify-dl/cli.js:164:38
at processTicksAndRejections (internal/process/task_queues.js:86:5)
errno: -2,
syscall: 'mkdir',
code: 'ENOENT',
path:
'/home/%username%/Music/Gold Cobra (Deluxe) - Limp Bizkit / Interscope' }