### PR TITLE
Fix possible type error

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -6,15 +6,11 @@ module.exports = {
     write: async (dir, counter) => {
         if (fs.existsSync(dir)) {
             fs.unlink(dir, function () {
-                fs.writeFile(dir, counter, function (err) {
-                    if (err) throw err;
-                });
+                fs.writeFile(dir, String(counter), err => { if (err) throw err });
             });
         }
         else {
-            fs.writeFile(dir, counter, function (err) {
-                if (err) throw err;
-            });
+            fs.writeFile(dir, String(counter), err => { if (err) throw err });
         }
     },
     read: async (dir, spinner) => {


### PR DESCRIPTION
Explicitly set the data argument for fs.writeFile to String to prevent the following error

TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received type number (2)