### PR TITLE
feat: failing download doesn't cause script to fail

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -77,20 +77,19 @@ if (!input[0]) {
     var spotifye = new songdata();
     for (const link of input) {
       const urlType = await urlParser(await filter.removeQuery(link));
-      var songData = {};
       const URL = link;
       let outputDir = path.normalize((cli.flags.output != null) ? cli.flags.output : process.cwd());
       switch(urlType) {
         case 'song': {
-          songData = await spotifye.getTrack(URL);
-          const songData = songData.name + ' ' + songData.artists[0];
-          
+          const songData = await spotifye.getTrack(URL);
+          const songName = songData.name + ' ' + songData.artists[0];
+
           const output = path.resolve(outputDir, await filter.validateOutput(`${songData.name} - ${songData.artists[0]}.mp3`));
           spinner.info(`Saving Song to: ${output}`);
 
           spinner.succeed(`Song: ${songData.name} - ${songData.artists[0]}`);
           
-          const youtubeLink = await getLink(songData);
+          const youtubeLink = await getLink(songName);
           spinner.start("Downloading...");
           
           await download(youtubeLink, output, spinner, async function() {
@@ -100,7 +99,7 @@ if (!input[0]) {
         }
         case 'playlist': {
           var cacheCounter = 0;
-          songData = await spotifye.getPlaylist(URL);
+          const songData = await spotifye.getPlaylist(URL);
 
           var dir = path.join(outputDir, filter.validateOutputSync(songData.name));
           spinner.info(`Total Songs: ${songData.total_tracks}`)
@@ -145,8 +144,8 @@ if (!input[0]) {
           break;
         }
         case 'album': {
-          var cacheCounter = 0;
-          songData = await spotifye.getAlbum(URL);
+          var cacheCounter = 0;          
+          const songData = await spotifye.getAlbum(URL);
           songData.name = songData.name.replace('/', '-');
           
           var dir = path.join(outputDir, await filter.validateOutput(songData.name));

--- a/cli.js
+++ b/cli.js
@@ -105,7 +105,7 @@ if (!input[0]) {
 
           spinner.info(`Total Songs: ${playlistData.total_tracks}`)
           spinner.info(`Saving Playlist: ${dir}`);
-          
+
           cacheCounter = await cache.read(dir, spinner);
           dir = path.join(dir, '.spdlcache');
           
@@ -146,26 +146,26 @@ if (!input[0]) {
         }
         case 'album': {
           var cacheCounter = 0;          
-          const songData = await spotifye.getAlbum(URL);
-          songData.name = songData.name.replace('/', '-');
+          const albumData = await spotifye.getAlbum(URL);
+          albumData.name = albumData.name.replace('/', '-');
           
-          var dir = path.join(outputDir, await filter.validateOutput(songData.name));
+          var dir = path.join(outputDir, await filter.validateOutput(albumData.name));
 
-          spinner.info(`Total Songs: ${songData.total_tracks}`);
-          spinner.info(`Saving Album: ` + path.join(outputDir, songData.name));
+          spinner.info(`Total Songs: ${albumData.total_tracks}`);
+          spinner.info(`Saving Album: ` + path.join(outputDir, albumData.name));
 
           cacheCounter = await cache.read(dir, spinner);
           dir = path.join(dir, '.spdlcache');
 
           async function downloadLoop(trackIds, counter) {
             const songData = await spotifye.extrTrack(trackIds[counter]);
-            counter++;
-            spinner.info(`${counter}. Song: ${songData.name} - ${songData.artists[0]}`);
-            counter--;
+
+            spinner.info(`${counter + 1}. Song: ${songData.name} - ${songData.artists[0]}`);
 
             const ytLink = await getLink(songData.name + ' ' + songData.artists[0]);
 
-            const output = path.resolve(outputDir, await filter.validateOutput(songData.name, `${songData.name} - ${songData.artists[0]}.mp3`));
+            const output = path.resolve(outputDir, filter.validateOutputSync(albumData.name), filter.validateOutputSync(`${songData.name} - ${songData.artists[0]}.mp3`));
+
             spinner.start("Downloading...");
 
             download(ytLink, output, spinner, async function (withError) {
@@ -189,7 +189,7 @@ if (!input[0]) {
             })
 
           }
-          downloadLoop(songData.tracks, cacheCounter);
+          downloadLoop(albumData.tracks, cacheCounter);
           break;
         }
         case 'artist': {

--- a/cli.js
+++ b/cli.js
@@ -120,16 +120,24 @@ if (!input[0]) {
             const output = path.resolve(outputDir, filter.validateOutputSync(songData.name), filter.validateOutputSync(`${songNam.name} - ${songNam.artists[0]}.mp3`));
             spinner.start("Downloading...");
 
-            download(ytLink, output, spinner, async function() {
+            download(ytLink, output, spinner, async function(withError) {
               await cache.write(dir, ++counter);
 
-              await mergeMetadata(output, songNam, spinner, function() {
+              if (withError) {
                 if(counter == trackIds.length) {
                   console.log(`\nFinished. Saved ${counter} Songs at ${output}.`);
                 } else {
                   downloadLoop(trackIds, counter);
                 }
-              });
+              } else {
+                await mergeMetadata(output, songNam, spinner, function() {
+                  if(counter == trackIds.length) {
+                    console.log(`\nFinished. Saved ${counter} Songs at ${output}.`);
+                  } else {
+                    downloadLoop(trackIds, counter);
+                  }
+                });
+              }
             })
 
           }

--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -13,7 +13,9 @@ const ffmpeg = require('fluent-ffmpeg');
 const downloader = (youtubeLink, output, spinner, callback) => {
   const download = ytdl(youtubeLink, options);
   download.on('progress', (chunk, downloaded, total) => {
-    spinner.text = `Downloading ${(downloaded / 1024 / 1024).toFixed(2)}MB of ${(total / 1024 / 1024).toFixed(2)}MB\n`;
+    spinner.text = `Downloading ${(downloaded / 1024 / 1024).toFixed(
+      2
+    )}MB of ${(total / 1024 / 1024).toFixed(2)}MB\n`;
   });
 
   ffmpeg(download)
@@ -21,12 +23,12 @@ const downloader = (youtubeLink, output, spinner, callback) => {
     .save(`${output}`)
     .on('end', () => {
       spinner.succeed('Download completed.');
-      if (typeof callback === "function") callback();
+      if (typeof callback === 'function') callback();
     })
-    //.on('error', () => {
-      //spinner.fail('Download failed.');
-      //if (typeof callback === "function") callback(true);
-    // });
+    .on('error', () => {
+      spinner.fail('Could not download song');
+      if (typeof callback === 'function') callback(true);
+    });
 };
 
 module.exports = downloader;

--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -24,7 +24,7 @@ const downloader = (youtubeLink, output, spinner, callback) => {
       if (typeof callback === "function") callback();
     })
     .on('error', () => {
-      spinner.fail('Something went wrong during download');
+      spinner.fail('Download failed.');
       if (typeof callback === "function") callback(true);
     });
 };

--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -22,6 +22,10 @@ const downloader = (youtubeLink, output, spinner, callback) => {
     .on('end', () => {
       spinner.succeed('Download completed.');
       if (typeof callback === "function") callback();
+    })
+    .on('error', () => {
+      spinner.fail('Something went wrong during download');
+      if (typeof callback === "function") callback(true);
     });
 };
 

--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -23,10 +23,10 @@ const downloader = (youtubeLink, output, spinner, callback) => {
       spinner.succeed('Download completed.');
       if (typeof callback === "function") callback();
     })
-    .on('error', () => {
-      spinner.fail('Download failed.');
-      if (typeof callback === "function") callback(true);
-    });
+    //.on('error', () => {
+      //spinner.fail('Download failed.');
+      //if (typeof callback === "function") callback(true);
+    // });
 };
 
 module.exports = downloader;

--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -30,20 +30,19 @@ const mergeMetadata = async (output, songdata, spinner, callback) => {
         // execSync(`ffmpeg -y -i \"${output}\" -i \"${cover}\" -c:a copy -c:v copy -map 0:0 -map 1:0 -id3v2_version 3 -metadata:s:v title="Album cover" -metadata:s:v comment="Cover (front)" \"${output}\"`);
         ffmetadata.write(output, metadata, {}, function(err) {
             if(err) {
-                throw new Error('Error writing Metadata!',err);
-            }
-            else {
-                if(spinner) {
-                    const tempPath = output.slice(0, output.length - 3) + 'temp.mp3'
-                    const stream = ffmpeg(output).addOutputOptions('-i', cover, '-map', '0:0', '-map', '1:0', '-c', 'copy', '-id3v2_version', '3').save(tempPath);
-                    stream.on('end', () => {
+                spinner.fail("Something went wrong - couldn't merge metadata");
+                return callback();
+            } else if (spinner) {
+                const tempPath = output.slice(0, output.length - 3) + 'temp.mp3'
+                const stream = ffmpeg(output).addOutputOptions('-i', cover, '-map', '0:0', '-map', '1:0', '-c', 'copy', '-id3v2_version', '3').save(tempPath);
+                stream
+                    .on('end', () => {
                         fs.unlinkSync(output);
                         fs.renameSync(tempPath, output);
                         fs.unlinkSync(cover);
                         spinner.succeed('Metadata Merged!');
                         if (typeof callback === "function") callback();
                     });
-                }
             }
         });
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "spotify-dl",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4580,9 +4580,9 @@
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
     },
     "miniget": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/miniget/-/miniget-2.0.1.tgz",
-      "integrity": "sha512-MX+QfVIPAutz6c+T7WKuFKtjcw0nOyRRh1ubhTDD+z/e/pKcSAsfAV63aQKUgb1MFRT1GyfJeW53N5fHkX0wIA=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/miniget/-/miniget-2.0.2.tgz",
+      "integrity": "sha512-rUYQiHXVjisRIuEdvIQxXPsAKp9Gltz5JdLWA8a3c/5265f2bZudg5mGtWcox0HHxkw51v8od/jLsqyYlM8UBw=="
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -6904,9 +6904,9 @@
       }
     },
     "ytdl-core": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/ytdl-core/-/ytdl-core-3.3.0.tgz",
-      "integrity": "sha512-jesZn1BCKanWEtVymezoJTMUF0B0Z6OQuf8M61zy0QUoNQprR2SYwzwI6dTOZHURz7wk1ffPgbYLu6BZq0vUsQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/ytdl-core/-/ytdl-core-3.4.2.tgz",
+      "integrity": "sha512-R6m1XZQK+iXxb9Q9Wo14/K8mti1r4HnKv4zKrbp5FvMG/jDbeV0xQHUHqqDLk+uiDy/VU6fVATm5x2ms0QaF5w==",
       "requires": {
         "html-entities": "^1.3.1",
         "m3u8stream": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "request": "^2.88.2",
     "spotify-web-api-node": "^4.0.0",
     "yt-search": "^2.3.1",
-    "ytdl-core": "^3.3.0"
+    "ytdl-core": "^3.4.2"
   },
   "xo": {
     "space": true,

--- a/util/get-link.js
+++ b/util/get-link.js
@@ -5,7 +5,9 @@ const youtubeSearch = require('yt-search');
 const search = promisify(youtubeSearch);
 
 function buildUrl(topResult) {
-  return (topResult.url.includes('https://youtube.com')) ? topResult.url : 'https://youtube.com' + topResult.url;
+  return topResult.url.includes('https://youtube.com')
+    ? topResult.url
+    : 'https://youtube.com' + topResult.url;
 }
 
 /**
@@ -14,24 +16,24 @@ function buildUrl(topResult) {
  * @param {String} songName name of song
  * @returns {Promise<String>} youtube link of music video
  */
-const getLink = async (songName) => {
+const getLink = async songName => {
   try {
     const result = await search(songName);
-    
+
     const [topResult] = result.videos;
 
-    const youtubeLink = buildUrl(topResult)
+    const youtubeLink = buildUrl(topResult);
 
     return youtubeLink;
   } catch (_) {
     try {
-      const result = await search(songName.replace('-', ' '))
+      const result = await search(songName.replace('-', ' '));
 
-      const [topResult] = result.videos
+      const [topResult] = result.videos;
 
-      const youtubeLink = buildUrl(topResult)
+      const youtubeLink = buildUrl(topResult);
 
-      return youtubeLink
+      return youtubeLink;
     } catch (error) {
       return error;
     }


### PR DESCRIPTION
Hi there! :) 

I started using the package like before the weekend but for some reason it was failing when merging metadata. 

I even saw an issue on that. 
I created a small fix for this bug.

When the download fails I added a note to the terminal that tells that something went wrong during fail. It doesn't crash anymore. Just skips the download and jumps to another song.

I know this code isn't the cleanest but it fixes the bug :) 