### PR TITLE
Add Dockerfile and Docker instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM debian:unstable
+
+RUN apt-get update && apt-get install --no-install-recommends --assume-yes npm ffmpeg && rm -rf /var/lib/apt/lists/*
+RUN npm install -g spotify-dl
+
+WORKDIR /download
+ENTRYPOINT ["spotifydl"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ PS: You may need to type `termux-setup-storage` first and allow storage permissi
 sh -c "$(curl -fsSL https://raw.githubusercontent.com/SwapnilSoni1999/spotify-dl/master/tools/termux.sh)"
 ```
 
+#### Docker
+
+Build docker image:
+```sh
+git clone https://github.com/SwapnilSoni1999/spotify-dl
+cd spotify-dl
+docker build -t spotify-dl .
+```
+
 <hr>
 
 # Usage
@@ -64,6 +73,12 @@ $ spotifydl https://open.spotify.com/track/xyz
 | --es | takes extra search string/term to be used for youtube search |
 
 <hr>
+
+## Docker
+```sh
+docker run -it --user=$(id -u):$(id -g) -v $(pwd):/download --rm spotify-dl <options-to-spotify-dl defaults to --help>
+docker run -it --user=$(id -u):$(id -g) -v $(pwd):/download --rm spotify-dl "https://open.spotify.com/...."
+```
 
 #### Acknowledgements
 


### PR DESCRIPTION
Normally I would tie down the versions better than this for the base image and Debian packages, but this worked and likely would continue to work as you keep your code updated.

