### PR TITLE
Fixes issue #96 where the folder name ends with a period('.')

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -72,7 +72,7 @@ const downloadLoop = async (listData, dir) => {
       `${songInfo.name} ${songInfo.artists[0]} ${extraSearch}`,
     );
     const output = path.resolve(
-      dir,
+      filter.validateDirSync(dir),
       filter.validateOutputSync(
         `${songInfo.name} - ${songInfo.artists[0]}.mp3`,
       ),

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -28,7 +28,8 @@ module.exports = {
         try {
           const ffmpeg_paths = execSync('which ffmpeg');
           if (ffmpeg_paths == null) {
-            console.error('ERROR: Cannot find ffmpeg! Install it first, why dont you read README.md on git!');
+            console.error('ERROR: Cannot find ffmpeg! Install it first, why \
+            dont you read README.md on git!');
             process.exit(-1);
           }
           else {
@@ -97,7 +98,8 @@ module.exports = {
         type: 'string',
         helpText: [
           '--extra-search "<term>" or --es "<term>"',
-          '* takes string for extra search term which gets concated to song search on youtube',
+          '* takes string for extra search term which gets \
+          concated to song search on youtube',
           '* with playlist and albums it will concat with each song.',
           'eg. $ spotifydl <url> --extra-search "lyrics"',
         ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "spotify-dl",
-  "version": "0.5.1",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.5.1",
+      "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.21.1",

--- a/util/filters.js
+++ b/util/filters.js
@@ -7,4 +7,7 @@ module.exports = {
   removeQuery: function (url) {
     return url.split('?')[0];
   },
+  validateDirSync: function (output) {
+    return output.replace(/[(.$)]/g, '');
+  },
 };


### PR DESCRIPTION
This fixes #96 by sanitizing the directory name and replacing the period with a empty string.

Other Minor patches:
* Make strings span multiline and wrap at 80 characters to abide by the limits
* Updated the package-lock.json with latest version.