### PR TITLE
Feature/adding logged in support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,15 @@ $ spotifydl https://open.spotify.com/track/xyz
 | ---- | ------------------------------------------------------------ |
 | -o   | takes valid output path argument                             |
 | --es | takes extra search string/term to be used for youtube search |
-
+| --oo | enforces all downloaded songs in the output dir              |
+| --st | download spotify saved tracks                                |
+| --sp | download spotify saved playlists                             |
+| --sa | download spotify saved albums                                |
+| -u   | spotify username (only needed in non tty)                    |
+| -p   | spotify password (only needed in non tty)                    |
+| -cf  | takes valid output file name path argument                   |
+| -v   | returns current version                                      |
+| -h   | outputs help text                                            |
 <hr>
 
 ## Docker

--- a/cli.js
+++ b/cli.js
@@ -39,7 +39,7 @@ const { inputs, extraSearch, output } = cliInputs();
 let outputDir;
 let nextTokenRefreshTime;
 const spotifyExtractor = new SpotifyExtractor();
-const spinner = ora('Searching…').start();
+const spinner = ora('Searching…\n').start();
 
 const verifyCredentials = async () => {
   if (!nextTokenRefreshTime || (nextTokenRefreshTime < new Date())) {
@@ -47,7 +47,7 @@ const verifyCredentials = async () => {
     nextTokenRefreshTime.setSeconds(
       nextTokenRefreshTime.getSeconds() + REFRESH_ACCESS_TOKEN_SECONDS,
     );
-    await spotifyExtractor.checkCredentials(URL);
+    await spotifyExtractor.checkCredentials();
   }
 };
 

--- a/cli.js
+++ b/cli.js
@@ -34,7 +34,7 @@ const REFRESH_ACCESS_TOKEN_SECONDS = 55 * 60;
 // setup ffmpeg
 ffmpegSetup(process.platform);
 
-const { inputs, extraSearch, output } = cliInputs();
+const { inputs, extraSearch, output, outputOnly } = cliInputs();
 
 let outputDir;
 let nextTokenRefreshTime;
@@ -52,7 +52,7 @@ const verifyCredentials = async () => {
 };
 
 const trackOutputDir = track => {
-  return path.join(
+  return outputOnly ? outputDir : path.join(
     outputDir,
     filter.cleanOutputPath(track.artist_name),
     filter.cleanOutputPath(track.album_name),
@@ -180,7 +180,9 @@ const run = async () => {
               album_name: URL,
               release_date: null,
               //todo can we get the youtube image?
-              cover_url: 'https://lh3.googleusercontent.com/z6Sl4j9zQ88oUKNy0G3PAMiVwy8DzQLh_ygyvBXv0zVNUZ_wQPN_n7EAR2By3dhoUpX7kTpaHjRPni1MHwKpaBJbpNqdEsHZsH4q',
+              cover_url: 'https://lh3.googleusercontent.com/z6Sl4j9zQ88oUKN \
+              y0G3PAMiVwy8DzQLh_ygyvBXv0zVNUZ_wQPN_n7EAR2By3dhoUpX7kTpaHjRP \
+              ni1MHwKpaBJbpNqdEsHZsH4q',
               id: URL,
               URL: URL,
             },

--- a/cli.js
+++ b/cli.js
@@ -19,6 +19,9 @@ const ora = require('ora');
 const getLink = require('./util/get-link');
 const SpotifyExtractor = require('./util/get-songdata');
 const filter = require('./util/filters');
+const {
+  INPUT_TYPES,
+} = require('./util/constants');
 
 const downloader = require('./lib/downloader');
 const cache = require('./lib/cache');
@@ -117,7 +120,7 @@ const run = async () => {
     outputDir = path.normalize(output);
     await verifyCredentials();
     switch (input.type) {
-      case 'song': {
+      case INPUT_TYPES.SONG: {
         const songData = await spotifyExtractor.getTrack(URL);
         const listData = {
           total_tracks: 1,
@@ -129,19 +132,19 @@ const run = async () => {
         await downloadSongList(listData);
         break;
       }
-      case 'playlist': {
+      case INPUT_TYPES.PLAYLIST: {
         await downloadSongList(
           await spotifyExtractor.getPlaylist(URL),
         );
         break;
       }
-      case 'album': {
+      case INPUT_TYPES.ALBUM: {
         await downloadSongList(
           await spotifyExtractor.getAlbum(URL),
         );
         break;
       }
-      case 'artist': {
+      case INPUT_TYPES.ARTIST: {
         const artistAlbumInfos = await spotifyExtractor
           .getArtistAlbums(URL);
         const artist = artistAlbumInfos.artist;
@@ -153,7 +156,27 @@ const run = async () => {
         }
         break;
       }
-      case 'youtube': {
+      case INPUT_TYPES.SAVED_ALBUMS: {
+        const savedAlbumsInfo = await spotifyExtractor
+          .getSavedAlbums(URL);
+        // const artist = artistAlbumInfos.artist;
+        // const albums = artistAlbumInfos.albums;
+        // outputDir = path.join(outputDir, artist.name);
+        // for (let x = 0; x < albums.length; x++) {
+        //   spinner.info(`Starting album ${x + 1}/${albums.length}`);
+        //   await downloadSongList(albums[x]);
+        // }
+        break;
+      }
+      case INPUT_TYPES.SAVED_PLAYLISTS: {
+        const savedPlaylistsInfo = await spotifyExtractor
+          .getSavedPlaylists(URL);
+      }
+      case INPUT_TYPES.SAVED_TRACKS: {
+        const savedTracksInfo = await spotifyExtractor
+          .getSavedTracks(URL);
+      }
+      case INPUT_TYPES.YOUTUBE: {
         const cleanedURL = filter.validateOutputSync(URL);
         let dir = path.join(
           outputDir,
@@ -173,15 +196,6 @@ const run = async () => {
           spinner.succeed(`All songs already downloaded for ${URL}!\n`);
         }
         break;
-      }
-      case 'savedAlbums': {
-        throw new Error('Not supported yet');
-      }
-      case 'savedPlaylists': {
-        throw new Error('Not supported yet');
-      }
-      case 'savedTracks': {
-        throw new Error('Not supported yet');
       }
       default: {
         throw new Error('Invalid URL type');

--- a/config.js
+++ b/config.js
@@ -1,3 +1,16 @@
 module.exports = {
-  quality: 'highestaudio',
+  youtubeDLConfig: {
+    quality: 'highestaudio',
+  },
+  flags: {
+    cacheFile: '.spdlcache',
+    output: './',
+    extraSearch: '',
+    password: '',
+    username: '',
+    savedAlbums: false,
+    savedPlaylists: false,
+    savedTracks: false,
+    outputOnly: false,
+  },
 };

--- a/config.js
+++ b/config.js
@@ -4,7 +4,7 @@ module.exports = {
   },
   flags: {
     cacheFile: '.spdlcache',
-    output: './',
+    output: process.cwd(),
     extraSearch: '',
     password: '',
     username: '',

--- a/lib/api.js
+++ b/lib/api.js
@@ -186,5 +186,62 @@ module.exports = {
     }
     return albums;
   },
+  extractSavedAlbums: async () => {
+    const savedAlbums = (await spotifyApi.getMySavedAlbums(
+      { limit: MAX_LIMIT_DEFAULT },
+    )).body;
+    let albums = savedAlbums.items;
+    if (savedAlbums.next) {
+      let offset = albums.length;
+      while (albums.length < savedAlbums.total) {
+        const additionalSavedAlbums = (await spotifyApi
+          .getMySavedAlbums(
+            { limit: MAX_LIMIT_DEFAULT, offset: offset },
+          )).body;
+
+        albums = albums.concat(additionalSavedAlbums.items);
+        offset += MAX_LIMIT_DEFAULT;
+      }
+    }
+    return albums;
+  },
+  extractSavedPlaylists: async () => {
+    const savedPlaylists = (await spotifyApi.getUserPlaylists(
+      { limit: MAX_LIMIT_DEFAULT },
+    )).body;
+    let playlists = savedPlaylists.items;
+    if (savedPlaylists.next) {
+      let offset = playlists.length;
+      while (playlists.length < savedPlaylists.total) {
+        const additionalSavedPlaylists = (await spotifyApi
+          .getMySavedAlbums(
+            { limit: MAX_LIMIT_DEFAULT, offset: offset },
+          )).body;
+
+        playlists = playlists.concat(additionalSavedPlaylists.items);
+        offset += MAX_LIMIT_DEFAULT;
+      }
+    }
+    return playlists;
+  },
+  extractSavedTracks: async () => {
+    const savedTracks = (await spotifyApi.getMySavedTracks(
+      { limit: MAX_LIMIT_DEFAULT },
+    )).body;
+    let tracks = savedTracks.items;
+    if (savedTracks.next) {
+      let offset = tracks.length;
+      while (tracks.length < savedTracks.total) {
+        const additionalSavedTracks = (await spotifyApi
+          .getMySavedAlbums(
+            { limit: MAX_LIMIT_DEFAULT, offset: offset },
+          )).body;
+
+        tracks = tracks.concat(additionalSavedTracks.items);
+        offset += MAX_LIMIT_DEFAULT;
+      }
+    }
+    return tracks;
+  },
 };
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -32,14 +32,15 @@ module.exports = {
       await this.refreshToken();
     }
   },
-  requestTokens: async () => {
-    const data = (await spotifyApi.clientCredentialsGrant()).body;
-    spotifyApi.setAccessToken(data['access_token']);
-    spotifyApi.setRefreshToken(data['refresh_token']);
+  requestTokens: async function () {
+    this.setTokens((await spotifyApi.clientCredentialsGrant()).body);
   },
-  refreshToken: async () => {
-    const data = (await spotifyApi.refreshAccessToken()).body;
-    spotifyApi.setAccessToken(data['access_token']);
+  refreshToken: async function () {
+    this.setTokens((await spotifyApi.refreshAccessToken()).body);
+  },
+  setTokens: tokens => {
+    spotifyApi.setAccessToken(tokens['access_token']);
+    spotifyApi.setRefreshToken(tokens['refresh_token']);
   },
   extractTrack: async trackId => {
     const data = (await spotifyApi.getTrack(trackId)).body;
@@ -129,7 +130,7 @@ module.exports = {
       artistId,
       { limit: MAX_LIMIT_DEFAULT },
     )).body;
-    const albums = artistAlbums.items;
+    let albums = artistAlbums.items;
     if (artistAlbums.next) {
       let offset = albums.length;
       while (albums.length < artistAlbums.total) {

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,5 +1,6 @@
 'use strict';
 const SpotifyWebApi = require('spotify-web-api-node');
+const open = require('open');
 const { cliInputs } = require('./setup');
 const {
   AUTH: { SCOPES, STATE },
@@ -11,10 +12,12 @@ const {
     CALLBACK_URI,
   },
 } = require('../util/constants');
+const express = require('express');
 
-var spotifyApi = new SpotifyWebApi({
   clientId: 'acc6302297e040aeb6e4ac1fbdfd62c3',
   clientSecret: '0e8439a1280a43aba9a5bc0a16f3f009',
+const spotifyApi = new SpotifyWebApi({
+  redirectUri: `http://${HOST}:${PORT}${CALLBACK_URI}`,
 });
 
 const scopes = [
@@ -26,11 +29,48 @@ const scopes = [
 module.exports = {
   spotifyApi,
   checkCredentials: async function () {
-    if (!await spotifyApi.getRefreshToken()) {
-      await this.requestTokens();
-    } else {
+    if (await spotifyApi.getRefreshToken()) {
       await this.refreshToken();
+    } else {
+      const {
+        inputs,
+      } = cliInputs();
+
+      const requiresLogin = inputs.find(input =>
+        input.type == INPUT_TYPES.SAVED_ALBUMS ||
+        input.type == INPUT_TYPES.SAVED_PLAYLISTS ||
+        input.type == INPUT_TYPES.SAVED_TRACKS,
+      );
+
+      if (requiresLogin) {
+        await this.requestAuthorizedTokens();
+      } else {
+        await this.requestTokens();
+      }
     }
+  },
+  requestAuthorizedTokens: async function () {
+    const app = express();
+    let resolve;
+    const getCode = new Promise(_resolve => {
+      resolve = _resolve;
+    });
+    app.get(CALLBACK_URI, function (req, res) {
+      resolve(req.query.code);
+      res.end('');
+    });
+    const server = await app.listen(PORT);
+
+    open(await spotifyApi.createAuthorizeURL(
+      scopes,
+      STATE,
+    ));
+
+    const code = await getCode;
+    this.setTokens(
+      (await spotifyApi.authorizationCodeGrant(code)).body,
+    );
+    server.close();
   },
   requestTokens: async function () {
     this.setTokens((await spotifyApi.clientCredentialsGrant()).body);

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,11 +1,28 @@
 'use strict';
 const SpotifyWebApi = require('spotify-web-api-node');
+const { cliInputs } = require('./setup');
+const {
+  AUTH: { SCOPES, STATE },
+  INPUT_TYPES,
+  MAX_LIMIT_DEFAULT,
+  SERVER: {
+    PORT,
+    HOST,
+    CALLBACK_URI,
+  },
+} = require('../util/constants');
 
 var spotifyApi = new SpotifyWebApi({
   clientId: 'acc6302297e040aeb6e4ac1fbdfd62c3',
   clientSecret: '0e8439a1280a43aba9a5bc0a16f3f009',
 });
-const MAX_LIMIT_DEFAULT = 50;
+
+const scopes = [
+  SCOPES.USERS_SAVED_PLAYLISTS,
+  SCOPES.USERS_SAVED_TRACKS_ALBUMS,
+  SCOPES.USERS_TOP_TRACKS,
+];
+
 module.exports = {
   spotifyApi,
   checkCredentials: async function () {

--- a/lib/api.js
+++ b/lib/api.js
@@ -82,25 +82,20 @@ module.exports = {
     spotifyApi.setAccessToken(tokens['access_token']);
     spotifyApi.setRefreshToken(tokens['refresh_token']);
   },
-  extractTrack: async trackId => {
-    const data = (await spotifyApi.getTrack(trackId)).body;
-    var details = {
-      name: '',
-      artists: [],
-      album_name: '',
-      release_date: '',
-      cover_url: '',
-    };
-    details.name = data.name;
-    data.artists.forEach(artist => {
-      details.artists.push(artist.name);
-    });
-    details.album_name = data.album.name;
-    details.release_date = data.album.release_date;
-    details.cover_url = data.album.images[0].url;
-    return details;
+  extractTrack: async function (trackId) {
+    return this.parseTrack((await spotifyApi.getTrack(trackId)).body);
   },
-  extractPlaylist: async playlistId => {
+  parseTrack: track => {
+    return {
+      name: track.name,
+      artists: track.artists.map(artist => artist.name),
+      album_name: track.album.name,
+      release_date: track.album.release_date,
+      cover_url: track.album.images[0].url,
+      id: track.id,
+    };
+  },
+  extractPlaylist: async function (playlistId) {
     const data = (await spotifyApi.getPlaylist(
       playlistId,
       { limit: MAX_LIMIT_DEFAULT },
@@ -108,26 +103,29 @@ module.exports = {
     const details = {
       name: '',
       total_tracks: 0,
-      tracks: data.tracks.items.map(item => item.track.id),
+      tracks: data.tracks.items.map(item => item.track),
     };
 
-    details.name = data.name + ' - '
-      + data.owner.display_name;
-    details.total_tracks = data.tracks.total;
+    details.name = `${data.name} - ${data.owner.display_name}`;
     if (data.tracks.next) {
       let offset = details.tracks.length;
-      while (details.tracks.length < details.total_tracks) {
+      while (details.tracks.length < data.tracks.total) {
         const playlistTracksData = (await spotifyApi
           .getPlaylistTracks(
             playlistId,
             { limit: MAX_LIMIT_DEFAULT, offset: offset },
           )).body;
         details.tracks = details.tracks.concat(
-          playlistTracksData.items.map(item => item.track.id),
+          playlistTracksData.items.map(item => item.track),
         );
         offset += MAX_LIMIT_DEFAULT;
       }
     }
+
+    details.tracks = details.tracks
+      .filter(track => track)
+      .map(track => this.parseTrack(track));
+    details.total_tracks = data.tracks.length;
     return details;
   },
   extractAlbum: async albumId => {
@@ -138,10 +136,10 @@ module.exports = {
     const details = {
       name: '',
       total_tracks: 0,
-      tracks: data.tracks.items.map(item => item.id),
+      artist: data.artists[0],
+      tracks: data.tracks.items,
     };
-    details.name = data.name + ' - ' + data.label;
-    details.total_tracks = data.tracks.total;
+    details.name = `${data.name} - ${data.label}`;
     if (data.tracks.next) {
       let offset = details.tracks.length;
       while (details.tracks.length < data.tracks.total) {
@@ -150,14 +148,18 @@ module.exports = {
             albumId,
             { limit: MAX_LIMIT_DEFAULT, offset: offset },
           )).body;
-        details.tracks = details.tracks
-          .concat(albumTracks.items.map(item => item.id));
+        details.tracks = details.tracks.concat(albumTracks.items);
         offset += MAX_LIMIT_DEFAULT;
       }
     }
+
+    details.tracks = details.tracks
+      .filter(track => track)
+      .map(track => this.parseTrack(track));
+    details.total_tracks = data.tracks.length;
     return details;
   },
-  extractArtist: async artistId => {
+  extractArtist: async function (artistId) {
     const data = (await spotifyApi.getArtist(artistId)).body;
     return {
       id: data.id,
@@ -165,7 +167,7 @@ module.exports = {
       href: data.href,
     };
   },
-  extractArtistAlbums: async artistId => {
+  extractArtistAlbums: async function (artistId) {
     const artistAlbums = (await spotifyApi.getArtistAlbums(
       artistId,
       { limit: MAX_LIMIT_DEFAULT },
@@ -184,9 +186,10 @@ module.exports = {
         offset += MAX_LIMIT_DEFAULT;
       }
     }
+
     return albums;
   },
-  extractSavedAlbums: async () => {
+  extractSavedAlbums: async function () {
     const savedAlbums = (await spotifyApi.getMySavedAlbums(
       { limit: MAX_LIMIT_DEFAULT },
     )).body;
@@ -203,9 +206,9 @@ module.exports = {
         offset += MAX_LIMIT_DEFAULT;
       }
     }
-    return albums;
+    return albums.map(album => album.album);
   },
-  extractSavedPlaylists: async () => {
+  extractSavedPlaylists: async function () {
     const savedPlaylists = (await spotifyApi.getUserPlaylists(
       { limit: MAX_LIMIT_DEFAULT },
     )).body;
@@ -214,7 +217,7 @@ module.exports = {
       let offset = playlists.length;
       while (playlists.length < savedPlaylists.total) {
         const additionalSavedPlaylists = (await spotifyApi
-          .getMySavedAlbums(
+          .getUserPlaylists(
             { limit: MAX_LIMIT_DEFAULT, offset: offset },
           )).body;
 
@@ -222,9 +225,10 @@ module.exports = {
         offset += MAX_LIMIT_DEFAULT;
       }
     }
+
     return playlists;
   },
-  extractSavedTracks: async () => {
+  extractSavedTracks: async function () {
     const savedTracks = (await spotifyApi.getMySavedTracks(
       { limit: MAX_LIMIT_DEFAULT },
     )).body;
@@ -233,7 +237,7 @@ module.exports = {
       let offset = tracks.length;
       while (tracks.length < savedTracks.total) {
         const additionalSavedTracks = (await spotifyApi
-          .getMySavedAlbums(
+          .getMySavedTracks(
             { limit: MAX_LIMIT_DEFAULT, offset: offset },
           )).body;
 
@@ -241,7 +245,7 @@ module.exports = {
         offset += MAX_LIMIT_DEFAULT;
       }
     }
-    return tracks;
+    return tracks.map(track => this.parseTrack(track.track));
   },
 };
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -82,16 +82,23 @@ module.exports = {
     spotifyApi.setAccessToken(tokens['access_token']);
     spotifyApi.setRefreshToken(tokens['refresh_token']);
   },
+  extractTracks: async function (tracks) {
+    const extractedTracks = [];
+    for (let x = 0; x < tracks.length; x++) {
+      extractedTracks.push(await this.extractTrack(tracks[x]));
+    }
+    return extractedTracks;
+  },
   extractTrack: async function (trackId) {
     return this.parseTrack((await spotifyApi.getTrack(trackId)).body);
   },
-  parseTrack: track => {
+  parseTrack: function (track) {
     return {
       name: track.name,
-      artists: track.artists.map(artist => artist.name),
+      artist_name: track.artists.map(artist => artist.name)[0],
       album_name: track.album.name,
       release_date: track.album.release_date,
-      cover_url: track.album.images[0].url,
+      cover_url: track.album.images.map(image => image.url)[0],
       id: track.id,
     };
   },
@@ -100,64 +107,56 @@ module.exports = {
       playlistId,
       { limit: MAX_LIMIT_DEFAULT },
     )).body;
-    const details = {
-      name: '',
-      total_tracks: 0,
-      tracks: data.tracks.items.map(item => item.track),
-    };
-
-    details.name = `${data.name} - ${data.owner.display_name}`;
+    let tracks = data.tracks.items.map(item => item.track);
     if (data.tracks.next) {
-      let offset = details.tracks.length;
-      while (details.tracks.length < data.tracks.total) {
+      let offset = tracks.length;
+      while (tracks.length < data.tracks.total) {
         const playlistTracksData = (await spotifyApi
           .getPlaylistTracks(
             playlistId,
             { limit: MAX_LIMIT_DEFAULT, offset: offset },
           )).body;
-        details.tracks = details.tracks.concat(
+        tracks = tracks.concat(
           playlistTracksData.items.map(item => item.track),
         );
         offset += MAX_LIMIT_DEFAULT;
       }
     }
 
-    details.tracks = details.tracks
-      .filter(track => track)
-      .map(track => this.parseTrack(track));
-    details.total_tracks = data.tracks.length;
-    return details;
+    return {
+      name: `${data.name} - ${data.owner.display_name}`,
+      tracks: tracks
+        .filter(track => track)
+        .map(track => this.parseTrack(track)),
+    };
   },
-  extractAlbum: async albumId => {
+  extractAlbum: async function (albumId) {
     const data = (await spotifyApi.getAlbum(
       albumId,
       { limit: MAX_LIMIT_DEFAULT },
     )).body;
-    const details = {
-      name: '',
-      total_tracks: 0,
-      artist: data.artists[0],
-      tracks: data.tracks.items,
-    };
-    details.name = `${data.name} - ${data.label}`;
+    let tracks = data.tracks.items;
     if (data.tracks.next) {
-      let offset = details.tracks.length;
-      while (details.tracks.length < data.tracks.total) {
+      let offset = tracks.length;
+      while (tracks.length < data.tracks.total) {
         const albumTracks = (await spotifyApi
           .getAlbumTracks(
             albumId,
             { limit: MAX_LIMIT_DEFAULT, offset: offset },
           )).body;
-        details.tracks = details.tracks.concat(albumTracks.items);
+        tracks = tracks.concat(albumTracks.items);
         offset += MAX_LIMIT_DEFAULT;
       }
     }
 
-    details.tracks = details.tracks
-      .filter(track => track)
-      .map(track => this.parseTrack(track));
-    details.total_tracks = data.tracks.length;
-    return details;
+    return {
+      name: `${data.name} - ${data.label}`,
+      tracks: await this.extractTracks(
+        tracks
+          .filter(track => track)
+          .map(track => track.id),
+      ),
+    };
   },
   extractArtist: async function (artistId) {
     const data = (await spotifyApi.getArtist(artistId)).body;
@@ -232,7 +231,7 @@ module.exports = {
     const savedTracks = (await spotifyApi.getMySavedTracks(
       { limit: MAX_LIMIT_DEFAULT },
     )).body;
-    let tracks = savedTracks.items;
+    let tracks = savedTracks.items.map(item => item.track);
     if (savedTracks.next) {
       let offset = tracks.length;
       while (tracks.length < savedTracks.total) {
@@ -241,11 +240,19 @@ module.exports = {
             { limit: MAX_LIMIT_DEFAULT, offset: offset },
           )).body;
 
-        tracks = tracks.concat(additionalSavedTracks.items);
+        tracks = tracks.concat(
+          additionalSavedTracks.items.map(item => item.track),
+        );
         offset += MAX_LIMIT_DEFAULT;
       }
     }
-    return tracks.map(track => this.parseTrack(track.track));
+
+    return {
+      name: 'Saved Tracks',
+      tracks: tracks
+        .filter(track => track)
+        .map(track => this.parseTrack(track)),
+    };
   },
 };
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -88,18 +88,21 @@ module.exports = {
       });
 
       const page = await browser.newPage();
-      await page.goto(authURL);
-      await page.type('#login-username', username);
-      await page.type('#login-password', password);
-      await page.click('#login-button');
-      await page.waitForSelector('#auth-accept');
-      await page.click('#auth-accept');
-      // for debug
-      // await page.waitForTimeout(3000);
-      // await page.screenshot({
-      //   path: './text.png',
-      //   fullPage: true,
-      // });
+      try {
+        await page.goto(authURL);
+        await page.type('#login-username', username);
+        await page.type('#login-password', password);
+        await page.click('#login-button');
+        await page.waitForSelector('#auth-accept');
+        await page.click('#auth-accept');
+      } catch (_e) {
+        console.log('Please find a screenshot of why the auto login failed at' +
+          './failure.png');
+        await page.screenshot({
+          path: './failure.png',
+          fullPage: true,
+        });
+      }
     } else {
       open(authURL);
     }

--- a/lib/api.js
+++ b/lib/api.js
@@ -14,9 +14,9 @@ const {
 } = require('../util/constants');
 const express = require('express');
 
+const spotifyApi = new SpotifyWebApi({
   clientId: 'acc6302297e040aeb6e4ac1fbdfd62c3',
   clientSecret: '0e8439a1280a43aba9a5bc0a16f3f009',
-const spotifyApi = new SpotifyWebApi({
   redirectUri: `http://${HOST}:${PORT}${CALLBACK_URI}`,
 });
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,6 +1,7 @@
 'use strict';
 const SpotifyWebApi = require('spotify-web-api-node');
 const open = require('open');
+const puppeteer = require('puppeteer');
 const { cliInputs } = require('./setup');
 const {
   AUTH: { SCOPES, STATE },
@@ -50,6 +51,11 @@ module.exports = {
     }
   },
   requestAuthorizedTokens: async function () {
+    const {
+      username,
+      password,
+    } = cliInputs();
+    const autoLogin = username.length > 0 && password.length > 0;
     const app = express();
     let resolve;
     const getCode = new Promise(_resolve => {
@@ -61,15 +67,50 @@ module.exports = {
     });
     const server = await app.listen(PORT);
 
-    open(await spotifyApi.createAuthorizeURL(
+    const authURL = await spotifyApi.createAuthorizeURL(
       scopes,
       STATE,
-    ));
+      autoLogin,
+    );
+
+    let browser = null;
+
+    if (autoLogin) {
+      browser = await puppeteer.launch({
+        args: [
+          // Required for Docker version of Puppeteer
+          '--no-sandbox',
+          '--disable-setuid-sandbox',
+          // This will write shared memory files into /tmp instead of /dev/shm,
+          // because Docker’s default for /dev/shm is 64MB
+          '--disable-dev-shm-usage',
+        ],
+      });
+
+      const page = await browser.newPage();
+      await page.goto(authURL);
+      await page.type('#login-username', username);
+      await page.type('#login-password', password);
+      await page.click('#login-button');
+      await page.waitForSelector('#auth-accept');
+      await page.click('#auth-accept');
+      // for debug
+      // await page.waitForTimeout(3000);
+      // await page.screenshot({
+      //   path: './text.png',
+      //   fullPage: true,
+      // });
+    } else {
+      open(authURL);
+    }
 
     const code = await getCode;
     this.setTokens(
       (await spotifyApi.authorizationCodeGrant(code)).body,
     );
+    if (browser) {
+      browser.close();
+    }
     server.close();
   },
   requestTokens: async function () {

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -10,16 +10,20 @@ module.exports = {
     return cacheFileIsRelative ?
       path.join(dir, cacheFile) : cacheFile;
   },
-  write: async function (dir, id) {
+  writeId: function (dir, id) {
     const cacheFile = this.getCacheFile(dir);
     fs.appendFileSync(cacheFile, `spotify ${id}\n`);
   },
-  read: async function (dir, spinner) {
+  findId: function (id, dir) {
     const cacheFile = this.getCacheFile(dir);
     fs.mkdirSync(dir, { recursive: true });
+    let cached = false;
     if (fs.existsSync(cacheFile)) {
-      spinner.info('Fetching cache to resume Download\n');
-      return fs.readFileSync(cacheFile, 'utf-8');
+      cached = fs.readFileSync(cacheFile, 'utf-8')
+        .split('\n')
+        .map(line => line.replace('spotify ', ''))
+        .find(line => line == id);
     }
+    return cached;
   },
 };

--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -1,6 +1,6 @@
 'use strict';
 const ytdl = require('ytdl-core');
-const options = require('../config');
+const { youtubeDLConfig } = require('../config');
 const ffmpeg = require('fluent-ffmpeg');
 
 /**
@@ -28,7 +28,7 @@ const downloader = async (youtubeLinks, output, spinner) => {
   };
   let attemptCount = 0;
   while (attemptCount < youtubeLinks.length) {
-    const download = ytdl(youtubeLinks[attemptCount], options);
+    const download = ytdl(youtubeLinks[attemptCount], youtubeDLConfig);
     spinner.start(`Trying youtube link ${attemptCount + 1}...`);
     download.on('progress', progressFunction);
     const doDownload = (resolve, reject) => {

--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -2,6 +2,33 @@
 const ytdl = require('ytdl-core');
 const { youtubeDLConfig } = require('../config');
 const ffmpeg = require('fluent-ffmpeg');
+const { SponsorBlock } = require('sponsorblock-api');
+const sponsorBlock = new SponsorBlock(1234);
+
+const sponsorComplexFilter = async link => {
+  const videoID = (new URLSearchParams((new URL(link)).search)).get('v');
+  let segments = [];
+  let complexFilter = null;
+  try {
+    segments = await sponsorBlock.getSegments(videoID, 'sponsor');
+  } catch (_) { }
+  const segmentLength = segments.length;
+  if (segmentLength) {
+    // 0 -> start1 , end1 -> start2, end2
+    const asetString = 'asetpts=PTS-STARTPTS';
+    complexFilter = segments.map((segment, i) => {
+      const startString = `start=${i ? segments[i - 1].endTime : 0}`;
+      const endString = `:end=${segment.startTime}`;
+      return `[0:a]atrim=${startString}${endString},${asetString}[${i}a];`;
+    });
+    complexFilter.push(`[0:a]atrim=start=${segments[segmentLength - 1].endTime}`
+      + `,${asetString}[${segmentLength}a];`);
+    complexFilter.push(`${complexFilter.map((_, i) => `[${i}a]`).join('')}` +
+      `concat=n=${segmentLength + 1}:v=0:a=1[outa]`);
+    complexFilter = complexFilter.join('\n');
+  }
+  return complexFilter;
+};
 
 /**
  * This function downloads the given youtube video 
@@ -28,11 +55,19 @@ const downloader = async (youtubeLinks, output, spinner) => {
   };
   let attemptCount = 0;
   while (attemptCount < youtubeLinks.length) {
-    const download = ytdl(youtubeLinks[attemptCount], youtubeDLConfig);
+    const link = youtubeLinks[attemptCount];
+    const download = ytdl(link, youtubeDLConfig);
     spinner.start(`Trying youtube link ${attemptCount + 1}...`);
     download.on('progress', progressFunction);
+    const complexFilter = await sponsorComplexFilter(link);
     const doDownload = (resolve, reject) => {
-      ffmpeg()
+      const ffmpegCommand = ffmpeg();
+      if (complexFilter) {
+        ffmpegCommand
+          .complexFilter(complexFilter)
+          .map('[outa]');
+      }
+      ffmpegCommand
         .on('error', e => {
           reject(e);
         })

--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -4,25 +4,59 @@ const { youtubeDLConfig } = require('../config');
 const ffmpeg = require('fluent-ffmpeg');
 const { SponsorBlock } = require('sponsorblock-api');
 const sponsorBlock = new SponsorBlock(1234);
+const {
+  SPONSOR_BLOCK: {
+    CATEGORIES: {
+      SPONSOR,
+      INTRO,
+      OUTRO,
+      INTERACTION,
+      SELF_PROMO,
+      MUSIC_OFF_TOPIC,
+    },
+  },
+  FFMPEG: {
+    ASET,
+  },
+} = require('../util/constants');
 
 const sponsorComplexFilter = async link => {
   const videoID = (new URLSearchParams((new URL(link)).search)).get('v');
   let segments = [];
   let complexFilter = null;
   try {
-    segments = await sponsorBlock.getSegments(videoID, 'sponsor');
+    segments = (await sponsorBlock.getSegments(
+      videoID,
+      SPONSOR,
+      INTRO,
+      OUTRO,
+      INTERACTION,
+      SELF_PROMO,
+      MUSIC_OFF_TOPIC,
+    )).sort((a, b) => a.startTime - b.startTime)
+      .reduce((acc, { startTime, endTime }) => {
+        const previousSegment = acc[acc.length - 1];
+        // if segments overlap merge
+        if (previousSegment && previousSegment.endTime > startTime) {
+          acc[acc.length - 1].endTime = endTime;
+        } else {
+          acc.push({ startTime, endTime });
+        }
+        return acc;
+      }, []);
+    // we have to catch as it throws if none found
   } catch (_) { }
   const segmentLength = segments.length;
   if (segmentLength) {
     // 0 -> start1 , end1 -> start2, end2
-    const asetString = 'asetpts=PTS-STARTPTS';
+    // we want everything but the segment `start -> end`
     complexFilter = segments.map((segment, i) => {
       const startString = `start=${i ? segments[i - 1].endTime : 0}`;
       const endString = `:end=${segment.startTime}`;
-      return `[0:a]atrim=${startString}${endString},${asetString}[${i}a];`;
+      return `[0:a]atrim=${startString}${endString},${ASET}[${i}a];`;
     });
     complexFilter.push(`[0:a]atrim=start=${segments[segmentLength - 1].endTime}`
-      + `,${asetString}[${segmentLength}a];`);
+      + `,${ASET}[${segmentLength}a];`);
     complexFilter.push(`${complexFilter.map((_, i) => `[${i}a]`).join('')}` +
       `concat=n=${segmentLength + 1}:v=0:a=1[outa]`);
     complexFilter = complexFilter.join('\n');

--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -7,14 +7,12 @@ const ffmpeg = require('fluent-ffmpeg');
  * This function downloads the given youtube video 
  * in best audio format as mp3 file
  *
- * @param {string} youtubeLink link of youtube video
+ * @param {array} youtubeLinks array of links of youtube videos
  * @param {string} output path/name of file to be downloaded(songname.mp3)
  * @param {*} spinner ora spinner to show download progress
  */
-const downloader = async (youtubeLink, output, spinner) => {
-  const download = ytdl(youtubeLink, options);
-  spinner.start('Downloading...');
-  download.on('progress', (_, downloaded, total) => {
+const downloader = async (youtubeLinks, output, spinner) => {
+  const progressFunction = (_, downloaded, total) => {
     const toBeDownloadedMb = (downloaded / 1024 / 1024).toFixed(2);
     const downloadedMb = (total / 1024 / 1024).toFixed(2);
     const isTTY = process.stdout.isTTY;
@@ -27,21 +25,35 @@ const downloader = async (youtubeLink, output, spinner) => {
         `Downloaded ${toBeDownloadedMb}/${downloadedMb} MB`,
       );
     }
-  });
+  };
+  let attemptCount = 0;
+  while (attemptCount < youtubeLinks.length) {
+    const download = ytdl(youtubeLinks[attemptCount], options);
+    spinner.start(`Trying youtube link ${attemptCount + 1}...`);
+    download.on('progress', progressFunction);
+    const doDownload = (resolve, reject) => {
+      ffmpeg()
+        .on('error', e => {
+          reject(e);
+        })
+        .on('end', () => {
+          resolve();
+        })
+        .input(download)
+        .audioBitrate(256)
+        .save(`${output}`)
+        .format('mp3');
+    };
 
-  await new Promise((resolve, reject) => {
-    ffmpeg()
-      .on('error', err => {
-        reject(err);
-      })
-      .on('end', () => {
-        resolve();
-      })
-      .input(download)
-      .audioBitrate(256)
-      .save(`${output}`)
-      .format('mp3');
-  });
+    try {
+      await new Promise(doDownload);
+      attemptCount = youtubeLinks.length;
+    } catch (e) {
+      spinner.info(e.message);
+      spinner.info('Youtube error retrying download');
+      attemptCount++;
+    }
+  }
   spinner.succeed('Download completed.');
 };
 

--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -19,7 +19,7 @@ const mergeMetadata = async (output, songData, spinner) => {
 
   await downloadAndSaveCover(songData.cover_url, coverFileName);
   const metadata = {
-    artist: songData.artists,
+    artist: songData.artist_name,
     album: songData.album_name,
     title: songData.name,
     date: songData.release_date,

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -4,6 +4,7 @@ const meow = require('meow');
 const urlParser = require('../util/url-parser');
 const { removeQuery } = require('../util/filters');
 const { INPUT_TYPES } = require('../util/constants');
+const config = require('../config');
 
 module.exports = {
   ffmpegSetup(platform_name) {
@@ -56,6 +57,9 @@ module.exports = {
       return false;
     };
 
+    const flagsConfig = config.flags;
+
+    // if you add a new flag make sure to add the default to the config
     const flags = {
       help: {
         alias: 'h',
@@ -76,7 +80,7 @@ module.exports = {
       cacheFile: {
         alias: 'cf',
         type: 'string',
-        default: '.spdlcache',
+        default: flagsConfig.cacheFile,
         helpText: [
           '--cache-file "<file-path>" or --cf "<file-path>"',
           '-takes relative or absolute file path argument',
@@ -86,6 +90,7 @@ module.exports = {
       output: {
         alias: 'o',
         type: 'string',
+        default: flagsConfig.output,
         helpText: [
           '--output "<path>" or -o "<path>"', '-takes valid path argument',
           'eg. $ spotifydl -o ~/songs <url>',
@@ -94,6 +99,7 @@ module.exports = {
       extraSearch: {
         alias: 'es',
         type: 'string',
+        default: flagsConfig.extraSearch,
         helpText: [
           '--extra-search "<term>" or --es "<term>"',
           '* takes string for extra search term which gets combined \
@@ -105,6 +111,7 @@ module.exports = {
       username: {
         alias: 'u',
         type: 'string',
+        default: flagsConfig.username,
         isRequired: loginRequired,
         helpText: [
           '--username "<username>" or -u "<username>"',
@@ -117,6 +124,7 @@ module.exports = {
       password: {
         alias: 'p',
         type: 'string',
+        default: flagsConfig.password,
         isRequired: loginRequired,
         helpText: [
           '--password "<password>" or -p "<password>"',
@@ -128,6 +136,8 @@ module.exports = {
       },
       savedAlbums: {
         alias: 'sa',
+        type: 'boolean',
+        default: flagsConfig.savedAlbums,
         helpText: [
           '--saved-albums or --sa',
           '* downloads a users saved albums',
@@ -138,6 +148,8 @@ module.exports = {
       },
       savedPlaylists: {
         alias: 'sp',
+        type: 'boolean',
+        default: flagsConfig.savedPlaylists,
         helpText: [
           '--saved-playlists or --sp',
           '* downloads a users saved playlists',
@@ -148,6 +160,8 @@ module.exports = {
       },
       savedTracks: {
         alias: 'st',
+        type: 'boolean',
+        default: flagsConfig.savedTracks,
         helpText: [
           '--saved-tracks or --st',
           '* downloads a users saved tracks',
@@ -207,12 +221,15 @@ module.exports = {
       };
     });
 
-    inputFlags.savedAlbums ?
-      inputs.push({ type: INPUT_TYPES.SAVED_ALBUMS, url: null }) : null;
-    inputFlags.savedTracks ?
-      inputs.push({ type: INPUT_TYPES.SAVED_TRACKS, url: null }) : null;
-    inputFlags.savedPlaylists ?
-      inputs.push({ type: INPUT_TYPES.SAVED_PLAYLISTS, url: null }) : null;
+    if (inputFlags.savedAlbums) {
+      inputs.push({ type: INPUT_TYPES.SAVED_ALBUMS, url: null });
+    }
+    if (inputFlags.savedTracks) {
+      inputs.push({ type: INPUT_TYPES.SAVED_TRACKS, url: null });
+    }
+    if (inputFlags.savedPlaylists) {
+      inputs.push({ type: INPUT_TYPES.SAVED_PLAYLISTS, url: null });
+    }
 
     if (!inputs.length) {
       console.log('See spotifydl --help for instructions');
@@ -224,6 +241,7 @@ module.exports = {
       extraSearch: inputFlags.extraSearch ? ` ${inputFlags.extraSearch}` : '',
       output: (inputFlags.output != null) ? inputFlags.output : process.cwd(),
       cacheFile: inputFlags.cacheFile,
+      outputOnly: inputFlags.outputOnly,
     };
   },
 };

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -116,8 +116,8 @@ module.exports = {
         helpText: [
           '--username "<username>" or -u "<username>"',
           '* takes string for spotify username',
-          '* required when using -sa, -sp and -st',
-          'NOT SUPPORTED YET',
+          '* optional when tty',
+          '* required when using -sa, -sp and -st in non tty',
           'eg. $ spotifydl -u "username"',
         ],
       },
@@ -129,8 +129,8 @@ module.exports = {
         helpText: [
           '--password "<password>" or -p "<password>"',
           '* takes string for spotify password',
-          '* required when using -sa, -sp and -st',
-          'NOT SUPPORTED YET',
+          '* optional when tty',
+          '* required when using -sa, -sp and -st in non tty',
           'eg. $ spotifydl -p "password"',
         ],
       },
@@ -197,8 +197,8 @@ module.exports = {
           $ spotifydl https://open.spotify.com/album/32Epx6wQXSulDr24Ez6vTE
           $ spotifydl https://open.spotify.com/artist/3vn7rk7VNMfDhuZNB9sDYP
           $ spotifydl -u username -p password -sa
-          $ spotifydl -u username -p password -sp
-          $ spotifydl -u username -p password -st
+          $ spotifydl -sp
+          $ spotifydl -st
           $ spotifydl <link> -cf <cache-file>
     
       Options
@@ -238,10 +238,12 @@ module.exports = {
 
     return {
       inputs: inputs,
-      extraSearch: inputFlags.extraSearch ? ` ${inputFlags.extraSearch}` : '',
-      output: (inputFlags.output != null) ? inputFlags.output : process.cwd(),
+      extraSearch: inputFlags.extraSearch,
+      output: inputFlags.output,
       cacheFile: inputFlags.cacheFile,
       outputOnly: inputFlags.outputOnly,
+      username: inputFlags.username,
+      password: inputFlags.password,
     };
   },
 };

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -29,7 +29,8 @@ module.exports = {
         try {
           const ffmpeg_paths = execSync('which ffmpeg');
           if (ffmpeg_paths == null) {
-            console.error('ERROR: Cannot find ffmpeg! Install it first, why dont you read README.md on git!');
+            console.error('ERROR: Cannot find ffmpeg! Install it first, \
+             why don\'t you read README.md on git!');
             process.exit(-1);
           }
           else {
@@ -45,9 +46,9 @@ module.exports = {
   },
   cliInputs() {
     const loginRequired = (flags, input) => {
-      if (flags.savedAlbums ||
+      if ((flags.savedAlbums ||
         flags.savedPlaylists ||
-        flags.savedSongs
+        flags.savedSongs) && !process.stdout.isTTY
       ) {
         return true;
       }
@@ -95,7 +96,8 @@ module.exports = {
         type: 'string',
         helpText: [
           '--extra-search "<term>" or --es "<term>"',
-          '* takes string for extra search term which gets concated to song search on youtube',
+          '* takes string for extra search term which gets combined \
+            to the song search on youtube',
           '* with playlist and albums it will concat with each song.',
           'eg. $ spotifydl <url> --extra-search "lyrics"',
         ],
@@ -129,8 +131,9 @@ module.exports = {
         helpText: [
           '--saved-albums or --sa',
           '* downloads a users saved albums',
-          'NOT SUPPORTED YET',
+          '* username and password required for non TTY',
           'eg. $ spotifydl -u "username" -p "password" -sa',
+          'eg. $ spotifydl -sa',
         ],
       },
       savedPlaylists: {
@@ -138,8 +141,9 @@ module.exports = {
         helpText: [
           '--saved-playlists or --sp',
           '* downloads a users saved playlists',
-          'NOT SUPPORTED YET',
+          '* username and password required for non TTY',
           'eg. $ spotifydl -u "username" -p "password" -sp',
+          'eg. $ spotifydl -sp',
         ],
       },
       savedTracks: {
@@ -147,7 +151,8 @@ module.exports = {
         helpText: [
           '--saved-tracks or --st',
           '* downloads a users saved tracks',
-          'NOT SUPPORTED YET',
+          '* username and password required for non TTY',
+          'eg. $ spotifydl -st',
           'eg. $ spotifydl -u "username" -p "password" -st',
         ],
       },

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -156,6 +156,16 @@ module.exports = {
           'eg. $ spotifydl -u "username" -p "password" -st',
         ],
       },
+      outputOnly: {
+        alias: 'oo',
+        default: flagsConfig.outputOnly,
+        type: 'boolean',
+        helpText: [
+          '--outputOnly or --oo',
+          '* saves all songs directly to the output dir',
+          'eg. $ spotifydl -oo',
+        ],
+      },
     };
 
     const helpText = '\n' + Object

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -3,6 +3,7 @@ const path = require('path');
 const meow = require('meow');
 const urlParser = require('../util/url-parser');
 const { removeQuery } = require('../util/filters');
+const { INPUT_TYPES } = require('../util/constants');
 
 module.exports = {
   ffmpegSetup(platform_name) {
@@ -195,11 +196,11 @@ module.exports = {
     });
 
     inputFlags.savedAlbums ?
-      inputs.push({ type: 'savedAlbums', url: null }) : null;
+      inputs.push({ type: INPUT_TYPES.SAVED_ALBUMS, url: null }) : null;
     inputFlags.savedTracks ?
-      inputs.push({ type: 'savedTracks', url: null }) : null;
+      inputs.push({ type: INPUT_TYPES.SAVED_TRACKS, url: null }) : null;
     inputFlags.savedPlaylists ?
-      inputs.push({ type: 'savedPlaylists', url: null }) : null;
+      inputs.push({ type: INPUT_TYPES.SAVED_PLAYLISTS, url: null }) : null;
 
     if (!inputs.length) {
       console.log('See spotifydl --help for instructions');

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -43,9 +43,6 @@ module.exports = {
         }
     }
   },
-  parseInputs() {
-
-  },
   cliInputs() {
     const loginRequired = (flags, input) => {
       if (flags.savedAlbums ||

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "ora": "^5.4.0",
         "puppeteer": "^8.0.0",
         "request": "^2.88.2",
+        "sponsorblock-api": "^0.1.3",
         "spotify-web-api-node": "^5.0.0",
         "yt-search": "^2.7.5",
         "ytdl-core": "^4.8.0"
@@ -2414,6 +2415,14 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
+      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
+      "dependencies": {
+        "node-fetch": "2.6.1"
       }
     },
     "node_modules/cross-spawn": {
@@ -8737,6 +8746,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sponsorblock-api": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/sponsorblock-api/-/sponsorblock-api-0.1.3.tgz",
+      "integrity": "sha512-7RnG9cPk+5oIeZ3iiKHs17ja5h6a2fXVYnRdqn9i9va4dEbQiWXl32t3ydbXIXcTh8sXMlpgfQFpIkErsc6qBA==",
+      "dependencies": {
+        "cross-fetch": "^3.0.6"
+      }
+    },
     "node_modules/spotify-web-api-node": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/spotify-web-api-node/-/spotify-web-api-node-5.0.2.tgz",
@@ -12370,6 +12387,14 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "cross-fetch": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
+      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
+      "requires": {
+        "node-fetch": "2.6.1"
       }
     },
     "cross-spawn": {
@@ -17347,6 +17372,14 @@
       "dev": true,
       "requires": {
         "extend-shallow": "^3.0.0"
+      }
+    },
+    "sponsorblock-api": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/sponsorblock-api/-/sponsorblock-api-0.1.3.tgz",
+      "integrity": "sha512-7RnG9cPk+5oIeZ3iiKHs17ja5h6a2fXVYnRdqn9i9va4dEbQiWXl32t3ydbXIXcTh8sXMlpgfQFpIkErsc6qBA==",
+      "requires": {
+        "cross-fetch": "^3.0.6"
       }
     },
     "spotify-web-api-node": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "meow": "^9.0.0",
         "open": "^8.0.9",
         "ora": "^5.4.0",
+        "puppeteer": "^8.0.0",
         "request": "^2.88.2",
         "spotify-web-api-node": "^5.0.0",
         "yt-search": "^2.7.5",
@@ -542,7 +543,7 @@
       "version": "15.0.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.2.tgz",
       "integrity": "sha512-p68+a+KoxpoB47015IeYZYRrdqMUcpbK8re/zpFB8Ld46LHC1lPEbp3EXgkEhAYEcPvjJF6ZO+869SQ0aH1dcA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.0",
@@ -554,6 +555,15 @@
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
+      "integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "3.10.1",
@@ -899,6 +909,17 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/ajv": {
@@ -1696,6 +1717,14 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -1906,6 +1935,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "node_modules/chrome-trace-event": {
       "version": "1.0.3",
@@ -2656,6 +2690,11 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.854822",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.854822.tgz",
+      "integrity": "sha512-xd4D8kHQtB0KtWW0c9xBZD5LVtm9chkMOfs/3Yn01RhT/sFIsVtzTtypfKoFfWBaL+7xCYLxjOLkhwPXaX/Kcg=="
+    },
     "node_modules/diffie-hellman": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
@@ -2841,7 +2880,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -4320,6 +4358,39 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extract-zip/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -4523,6 +4594,14 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
       "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
     },
     "node_modules/ffmetadata": {
       "version": "1.7.0",
@@ -4741,6 +4820,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
     "node_modules/fs-extra": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -4759,8 +4843,7 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -4849,7 +4932,6 @@
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
       "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -5226,6 +5308,18 @@
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/human-time": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/human-time/-/human-time-0.0.2.tgz",
@@ -5337,7 +5431,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -6598,6 +6691,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -6656,6 +6754,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
     },
     "node_modules/node-fzf": {
       "version": "0.5.3",
@@ -7050,7 +7156,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -7329,7 +7434,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7378,6 +7482,11 @@
         "node": ">=0.12"
       }
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+    },
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -7408,7 +7517,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
       "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-      "dev": true,
       "dependencies": {
         "find-up": "^4.0.0"
       },
@@ -7507,7 +7615,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -7532,6 +7639,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/psl": {
       "version": "1.8.0",
@@ -7562,7 +7674,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -7586,6 +7697,29 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/puppeteer": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-8.0.0.tgz",
+      "integrity": "sha512-D0RzSWlepeWkxPPdK3xhTcefj8rjah1791GE82Pdjsri49sy11ci/JQsAO8K2NRukqvwEtcI+ImP5F4ZiMvtIQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "debug": "^4.1.0",
+        "devtools-protocol": "0.0.854822",
+        "extract-zip": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.1",
+        "pkg-dir": "^4.2.0",
+        "progress": "^2.0.1",
+        "proxy-from-env": "^1.1.0",
+        "rimraf": "^3.0.2",
+        "tar-fs": "^2.0.0",
+        "unbzip2-stream": "^1.3.3",
+        "ws": "^7.2.3"
+      },
+      "engines": {
+        "node": ">=10.18.1"
       }
     },
     "node_modules/qs": {
@@ -7995,7 +8129,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -9056,6 +9189,32 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/term-size": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
@@ -9459,6 +9618,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/unbzip2-stream": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+      "dependencies": {
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
       }
     },
     "node_modules/unc-path-regex": {
@@ -9936,8 +10104,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "node_modules/write-file-atomic": {
       "version": "3.0.3",
@@ -9949,6 +10116,26 @@
         "is-typedarray": "^1.0.0",
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "node_modules/ws": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xdg-basedir": {
@@ -10147,6 +10334,15 @@
       "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yocto-queue": {
@@ -10651,7 +10847,7 @@
       "version": "15.0.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.2.tgz",
       "integrity": "sha512-p68+a+KoxpoB47015IeYZYRrdqMUcpbK8re/zpFB8Ld46LHC1lPEbp3EXgkEhAYEcPvjJF6ZO+869SQ0aH1dcA==",
-      "dev": true
+      "devOptional": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -10663,6 +10859,15 @@
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
+    },
+    "@types/yauzl": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
+      "integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
+      "optional": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "3.10.1",
@@ -10931,6 +11136,14 @@
       "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
       "dev": true,
       "requires": {}
+    },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "requires": {
+        "debug": "4"
+      }
     },
     "ajv": {
       "version": "6.12.6",
@@ -11595,6 +11808,11 @@
         }
       }
     },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -11746,6 +11964,11 @@
         "lodash.reject": "^4.4.0",
         "lodash.some": "^4.4.0"
       }
+    },
+    "chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "chrome-trace-event": {
       "version": "1.0.3",
@@ -12362,6 +12585,11 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
+    "devtools-protocol": {
+      "version": "0.0.854822",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.854822.tgz",
+      "integrity": "sha512-xd4D8kHQtB0KtWW0c9xBZD5LVtm9chkMOfs/3Yn01RhT/sFIsVtzTtypfKoFfWBaL+7xCYLxjOLkhwPXaX/Kcg=="
+    },
     "diffie-hellman": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
@@ -12531,7 +12759,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -13709,6 +13936,27 @@
         }
       }
     },
+    "extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "requires": {
+        "@types/yauzl": "^2.9.1",
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        }
+      }
+    },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -13887,6 +14135,14 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
       "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
     },
+    "fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+      "requires": {
+        "pend": "~1.2.0"
+      }
+    },
     "ffmetadata": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/ffmetadata/-/ffmetadata-1.7.0.tgz",
@@ -14047,6 +14303,11 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
     "fs-extra": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -14062,8 +14323,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "function-bind": {
       "version": "1.1.1",
@@ -14131,7 +14391,6 @@
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
       "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -14426,6 +14685,15 @@
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
     },
+    "https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      }
+    },
     "human-time": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/human-time/-/human-time-0.0.2.tgz",
@@ -14495,7 +14763,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -15467,6 +15734,11 @@
         "is-extendable": "^1.0.1"
       }
     },
+    "mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -15519,6 +15791,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+    },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-fzf": {
       "version": "0.5.3",
@@ -15829,7 +16106,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -16039,8 +16315,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
       "version": "3.1.1",
@@ -16077,6 +16352,11 @@
         "sha.js": "^2.4.8"
       }
     },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -16098,7 +16378,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
       "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-      "dev": true,
       "requires": {
         "find-up": "^4.0.0"
       }
@@ -16166,8 +16445,7 @@
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
     },
     "proto-props": {
       "version": "2.0.0",
@@ -16183,6 +16461,11 @@
         "forwarded": "~0.1.2",
         "ipaddr.js": "1.9.1"
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "psl": {
       "version": "1.8.0",
@@ -16215,7 +16498,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -16233,6 +16515,25 @@
       "dev": true,
       "requires": {
         "escape-goat": "^2.0.0"
+      }
+    },
+    "puppeteer": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-8.0.0.tgz",
+      "integrity": "sha512-D0RzSWlepeWkxPPdK3xhTcefj8rjah1791GE82Pdjsri49sy11ci/JQsAO8K2NRukqvwEtcI+ImP5F4ZiMvtIQ==",
+      "requires": {
+        "debug": "^4.1.0",
+        "devtools-protocol": "0.0.854822",
+        "extract-zip": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.1",
+        "pkg-dir": "^4.2.0",
+        "progress": "^2.0.1",
+        "proxy-from-env": "^1.1.0",
+        "rimraf": "^3.0.2",
+        "tar-fs": "^2.0.0",
+        "unbzip2-stream": "^1.3.3",
+        "ws": "^7.2.3"
       }
     },
     "qs": {
@@ -16555,7 +16856,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -17428,6 +17728,29 @@
       "integrity": "sha1-KcNXB8K3DlDQdIK10gLo7URtr9Q=",
       "dev": true
     },
+    "tar-fs": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "requires": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "requires": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      }
+    },
     "term-size": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
@@ -17737,6 +18060,15 @@
         "has-bigints": "^1.0.1",
         "has-symbols": "^1.0.2",
         "which-boxed-primitive": "^1.0.2"
+      }
+    },
+    "unbzip2-stream": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+      "requires": {
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
       }
     },
     "unc-path-regex": {
@@ -18126,8 +18458,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write-file-atomic": {
       "version": "3.0.3",
@@ -18140,6 +18471,12 @@
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
       }
+    },
+    "ws": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "requires": {}
     },
     "xdg-basedir": {
       "version": "4.0.0",
@@ -18294,6 +18631,15 @@
       "version": "20.2.7",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz",
       "integrity": "sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw=="
+    },
+    "yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+      "requires": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,19 @@
 {
   "name": "spotify-dl",
-  "version": "0.5.1",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.5.1",
+      "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.21.1",
+        "express": "^4.17.1",
         "ffmetadata": "^1.7.0",
         "fluent-ffmpeg": "^2.1.2",
         "meow": "^9.0.0",
+        "open": "^8.0.9",
         "ora": "^5.4.0",
         "request": "^2.88.2",
         "spotify-web-api-node": "^5.0.0",
@@ -22,6 +24,7 @@
         "spotifydl": "cli.js"
       },
       "devDependencies": {
+        "eslint": "^7.26.0",
         "prettier": "^2.2.1",
         "xo": "^0.32.1"
       }
@@ -381,9 +384,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.0.tgz",
-      "integrity": "sha512-2ZPCc+uNbjV5ERJr+aKSPRwZgKd2z11x0EgLvb1PURmUrn9QNRXFqje0Ldq454PfAVyaJYyrDvvIKSFP4NnBog==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.1.tgz",
+      "integrity": "sha512-5v7TDE9plVhvxQeWLXDTvFvJBdH6pEsdnl2g/dAptmuFEPedQ4Erq5rsDsX+mvAM610IhNaO2W5V1dOOnDKxkQ==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -865,6 +868,18 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/accepts": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+      "dependencies": {
+        "mime-types": "~2.1.24",
+        "negotiator": "0.6.2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -1069,6 +1084,11 @@
       "resolved": "https://registry.npmjs.org/array-find/-/array-find-1.0.0.tgz",
       "integrity": "sha1-bI4obRHtdoMn+OYuzuhzU8o+eLg=",
       "dev": true
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "node_modules/array-includes": {
       "version": "3.1.3",
@@ -1417,6 +1437,47 @@
       "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
       "dev": true
     },
+    "node_modules/body-parser": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+      "dependencies": {
+        "bytes": "3.1.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "on-finished": "~2.3.0",
+        "qs": "6.7.0",
+        "raw-body": "2.4.0",
+        "type-is": "~1.6.17"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "node_modules/body-parser/node_modules/qs": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -1672,6 +1733,14 @@
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
+    },
+    "node_modules/bytes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/cache-base": {
       "version": "1.0.1",
@@ -2170,6 +2239,30 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-disposition/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
@@ -2184,6 +2277,19 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
+    },
+    "node_modules/cookie": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "node_modules/cookiejar": {
       "version": "2.1.2",
@@ -2486,6 +2592,14 @@
       "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
       "dev": true
     },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -2519,6 +2633,14 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/des.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
@@ -2528,6 +2650,11 @@
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
       }
+    },
+    "node_modules/destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "node_modules/diffie-hellman": {
       "version": "5.0.3",
@@ -2664,6 +2791,11 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.3.727",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.727.tgz",
@@ -2696,6 +2828,14 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
@@ -2878,6 +3018,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -2887,13 +3032,13 @@
       }
     },
     "node_modules/eslint": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.25.0.tgz",
-      "integrity": "sha512-TVpSovpvCNpLURIScDRB6g5CYu/ZFq9GfX2hLNIV4dSBKxIWojeDODvYl3t0k0VtMxYeR8OXPCFE5+oHMlGfhw==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.26.0.tgz",
+      "integrity": "sha512-4R1ieRf52/izcZE7AlLy56uIHHDLT74Yzz2Iv2l6kDaYvEu9x+wMB5dZArVL8SYGXSYV2YAg70FcW5Y5nGGNIg==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
-        "@eslint/eslintrc": "^0.4.0",
+        "@eslint/eslintrc": "^0.4.1",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -3853,6 +3998,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/event-emitter": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
@@ -4017,6 +4170,72 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
+    },
+    "node_modules/express": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+      "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+      "dependencies": {
+        "accepts": "~1.3.7",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.19.0",
+        "content-disposition": "0.5.3",
+        "content-type": "~1.0.4",
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.5",
+        "qs": "6.7.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.1.2",
+        "send": "0.17.1",
+        "serve-static": "1.14.1",
+        "setprototypeof": "1.1.1",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "node_modules/express/node_modules/qs": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/express/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/ext": {
       "version": "1.4.0",
@@ -4341,6 +4560,36 @@
         "node": ">=8"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/finalhandler/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
     "node_modules/find-cache-dir": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
@@ -4464,6 +4713,14 @@
         "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -4474,6 +4731,14 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/fs-extra": {
@@ -4921,6 +5186,26 @@
       "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
       "dev": true
     },
+    "node_modules/http-errors": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-errors/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
     "node_modules/http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -4945,6 +5230,17 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/human-time/-/human-time-0.0.2.tgz",
       "integrity": "sha512-sbYI90YhYmstslPTb70BLGjy6mdESa0lxL7uDR4fIVAx9Iobz8fLEqi7FqF4Q/6vblrzZALg//MsYJlIPBU8SA=="
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -5063,6 +5359,14 @@
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
       "dev": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "engines": {
         "node": ">= 0.10"
       }
@@ -5207,6 +5511,20 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-error": {
@@ -5507,12 +5825,14 @@
       }
     },
     "node_modules/is-wsl": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
-      "dev": true,
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
       "engines": {
-        "node": ">=4"
+        "node": ">=8"
       }
     },
     "node_modules/is-yarn-global": {
@@ -6035,6 +6355,14 @@
         "safe-buffer": "^5.1.2"
       }
     },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/memoizee": {
       "version": "0.4.15",
       "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.15.tgz",
@@ -6085,6 +6413,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -6303,6 +6636,14 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
@@ -6694,6 +7035,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -6718,15 +7070,19 @@
       }
     },
     "node_modules/open": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
-      "integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
-      "dev": true,
+      "version": "8.0.9",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.0.9.tgz",
+      "integrity": "sha512-vbCrqMav3K8mCCy8NdK4teUky0tpDrBbuiDLduCdVhc5oA9toJMip9rBkuwdwSI9E7NOkz4VkLWPi8DD2MP1gQ==",
       "dependencies": {
-        "is-wsl": "^1.1.0"
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/open-editor": {
@@ -6738,6 +7094,27 @@
         "env-editor": "^0.4.0",
         "line-column-path": "^2.0.0",
         "open": "^6.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/open-editor/node_modules/is-wsl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/open-editor/node_modules/open": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
+      "integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
+      "dev": true,
+      "dependencies": {
+        "is-wsl": "^1.1.0"
       },
       "engines": {
         "node": ">=8"
@@ -6911,6 +7288,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
@@ -6962,6 +7347,11 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -7131,6 +7521,18 @@
         "node": ">=4"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
+      "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
+      "dependencies": {
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -7237,6 +7639,28 @@
       "dependencies": {
         "randombytes": "^2.0.5",
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+      "dependencies": {
+        "bytes": "3.1.0",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/rc": {
@@ -7684,6 +8108,58 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/send": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.7.2",
+        "mime": "1.6.0",
+        "ms": "2.1.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/send/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "node_modules/send/node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+    },
     "node_modules/serialize-javascript": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
@@ -7692,6 +8168,20 @@
       "peer": true,
       "dependencies": {
         "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+      "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+      "dependencies": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.17.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/set-value": {
@@ -7735,6 +8225,11 @@
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
       "dev": true
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
     "node_modules/sha.js": {
       "version": "2.4.11",
@@ -8241,6 +8736,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/stream-browserify": {
@@ -8778,6 +9281,14 @@
       "resolved": "https://registry.npmjs.org/to-utf8/-/to-utf8-0.0.1.tgz",
       "integrity": "sha1-0Xrqcv8vujm55DYBvns/9y4ImFI="
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -8901,6 +9412,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -8990,6 +9513,14 @@
       "dev": true,
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/unset-value": {
@@ -9152,6 +9683,14 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/uuid": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -9173,6 +9712,14 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/verror": {
@@ -9968,9 +10515,9 @@
       }
     },
     "@eslint/eslintrc": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.0.tgz",
-      "integrity": "sha512-2ZPCc+uNbjV5ERJr+aKSPRwZgKd2z11x0EgLvb1PURmUrn9QNRXFqje0Ldq454PfAVyaJYyrDvvIKSFP4NnBog==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.1.tgz",
+      "integrity": "sha512-5v7TDE9plVhvxQeWLXDTvFvJBdH6pEsdnl2g/dAptmuFEPedQ4Erq5rsDsX+mvAM610IhNaO2W5V1dOOnDKxkQ==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
@@ -10363,6 +10910,15 @@
       "dev": true,
       "peer": true
     },
+    "accepts": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+      "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+      "requires": {
+        "mime-types": "~2.1.24",
+        "negotiator": "0.6.2"
+      }
+    },
     "acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -10512,6 +11068,11 @@
       "resolved": "https://registry.npmjs.org/array-find/-/array-find-1.0.0.tgz",
       "integrity": "sha1-bI4obRHtdoMn+OYuzuhzU8o+eLg=",
       "dev": true
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "array-includes": {
       "version": "3.1.3",
@@ -10812,6 +11373,43 @@
       "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
       "dev": true
     },
+    "body-parser": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+      "requires": {
+        "bytes": "3.1.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "on-finished": "~2.3.0",
+        "qs": "6.7.0",
+        "raw-body": "2.4.0",
+        "type-is": "~1.6.17"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+        }
+      }
+    },
     "boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -11015,6 +11613,11 @@
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
+    },
+    "bytes": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
     },
     "cache-base": {
       "version": "1.0.1",
@@ -11415,6 +12018,26 @@
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
     },
+    "content-disposition": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
+      }
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+    },
     "convert-source-map": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
@@ -11431,6 +12054,16 @@
           "dev": true
         }
       }
+    },
+    "cookie": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+      "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "cookiejar": {
       "version": "2.1.2",
@@ -11680,6 +12313,11 @@
       "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
       "dev": true
     },
+    "define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="
+    },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -11704,6 +12342,11 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
     "des.js": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
@@ -11713,6 +12356,11 @@
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
       }
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "diffie-hellman": {
       "version": "5.0.3",
@@ -11834,6 +12482,11 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
     "electron-to-chromium": {
       "version": "1.3.727",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.727.tgz",
@@ -11868,6 +12521,11 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -12020,19 +12678,24 @@
       "integrity": "sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==",
       "dev": true
     },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.25.0.tgz",
-      "integrity": "sha512-TVpSovpvCNpLURIScDRB6g5CYu/ZFq9GfX2hLNIV4dSBKxIWojeDODvYl3t0k0VtMxYeR8OXPCFE5+oHMlGfhw==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.26.0.tgz",
+      "integrity": "sha512-4R1ieRf52/izcZE7AlLy56uIHHDLT74Yzz2Iv2l6kDaYvEu9x+wMB5dZArVL8SYGXSYV2YAg70FcW5Y5nGGNIg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
-        "@eslint/eslintrc": "^0.4.0",
+        "@eslint/eslintrc": "^0.4.1",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -12769,6 +13432,11 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
     "event-emitter": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
@@ -12904,6 +13572,68 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
+        }
+      }
+    },
+    "express": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+      "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+      "requires": {
+        "accepts": "~1.3.7",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.19.0",
+        "content-disposition": "0.5.3",
+        "content-type": "~1.0.4",
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.5",
+        "qs": "6.7.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.1.2",
+        "send": "0.17.1",
+        "serve-static": "1.14.1",
+        "setprototypeof": "1.1.1",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "qs": {
+          "version": "6.7.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
       }
     },
@@ -13187,6 +13917,35 @@
         "to-regex-range": "^5.0.1"
       }
     },
+    "finalhandler": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "find-cache-dir": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
@@ -13269,6 +14028,11 @@
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
       "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q=="
     },
+    "forwarded": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+    },
     "fragment-cache": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
@@ -13277,6 +14041,11 @@
       "requires": {
         "map-cache": "^0.2.2"
       }
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "fs-extra": {
       "version": "9.1.0",
@@ -13622,6 +14391,25 @@
       "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
       "dev": true
     },
+    "http-errors": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.1",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        }
+      }
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -13642,6 +14430,14 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/human-time/-/human-time-0.0.2.tgz",
       "integrity": "sha512-sbYI90YhYmstslPTb70BLGjy6mdESa0lxL7uDR4fIVAx9Iobz8fLEqi7FqF4Q/6vblrzZALg//MsYJlIPBU8SA=="
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
     },
     "ieee754": {
       "version": "1.2.1",
@@ -13721,6 +14517,11 @@
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
       "dev": true
+    },
+    "ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
     "irregular-plurals": {
       "version": "2.0.0",
@@ -13821,6 +14622,11 @@
         "is-data-descriptor": "^1.0.0",
         "kind-of": "^6.0.2"
       }
+    },
+    "is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="
     },
     "is-error": {
       "version": "2.2.2",
@@ -14033,10 +14839,12 @@
       "dev": true
     },
     "is-wsl": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
-      "dev": true
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "requires": {
+        "is-docker": "^2.0.0"
+      }
     },
     "is-yarn-global": {
       "version": "0.3.0",
@@ -14466,6 +15274,11 @@
         "safe-buffer": "^5.1.2"
       }
     },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
     "memoizee": {
       "version": "0.4.15",
       "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.15.tgz",
@@ -14512,6 +15325,11 @@
         "type-fest": "^0.18.0",
         "yargs-parser": "^20.2.3"
       }
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -14684,6 +15502,11 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "negotiator": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
     "neo-async": {
       "version": "2.6.2",
@@ -14994,6 +15817,14 @@
         "has": "^1.0.3"
       }
     },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -15012,12 +15843,13 @@
       }
     },
     "open": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
-      "integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
-      "dev": true,
+      "version": "8.0.9",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.0.9.tgz",
+      "integrity": "sha512-vbCrqMav3K8mCCy8NdK4teUky0tpDrBbuiDLduCdVhc5oA9toJMip9rBkuwdwSI9E7NOkz4VkLWPi8DD2MP1gQ==",
       "requires": {
-        "is-wsl": "^1.1.0"
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
       }
     },
     "open-editor": {
@@ -15029,6 +15861,23 @@
         "env-editor": "^0.4.0",
         "line-column-path": "^2.0.0",
         "open": "^6.2.0"
+      },
+      "dependencies": {
+        "is-wsl": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+          "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+          "dev": true
+        },
+        "open": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
+          "integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
+          "dev": true,
+          "requires": {
+            "is-wsl": "^1.1.0"
+          }
+        }
       }
     },
     "optionator": {
@@ -15159,6 +16008,11 @@
         "lines-and-columns": "^1.1.6"
       }
     },
+    "parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
     "pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
@@ -15198,6 +16052,11 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "path-type": {
       "version": "4.0.0",
@@ -15316,6 +16175,15 @@
       "integrity": "sha512-2yma2tog9VaRZY2mn3Wq51uiSW4NcPYT1cQdBagwyrznrilKSZwIZ0UG3ZPL/mx+axEns0hE35T5ufOYZXEnBQ==",
       "dev": true
     },
+    "proxy-addr": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
+      "integrity": "sha512-dh/frvCBVmSsDYzw6n926jv974gddhkFPfiN8hPOi30Wax25QZyZEGveluCgliBnqmuM+UJmBErbAUFIoDbjOw==",
+      "requires": {
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.9.1"
+      }
+    },
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -15406,6 +16274,22 @@
       "requires": {
         "randombytes": "^2.0.5",
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+    },
+    "raw-body": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+      "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+      "requires": {
+        "bytes": "3.1.0",
+        "http-errors": "1.7.2",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
       }
     },
     "rc": {
@@ -15747,6 +16631,53 @@
         }
       }
     },
+    "send": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+      "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.7.2",
+        "mime": "1.6.0",
+        "ms": "2.1.1",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            }
+          }
+        },
+        "mime": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
     "serialize-javascript": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
@@ -15755,6 +16686,17 @@
       "peer": true,
       "requires": {
         "randombytes": "^2.1.0"
+      }
+    },
+    "serve-static": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+      "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+      "requires": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.17.1"
       }
     },
     "set-value": {
@@ -15791,6 +16733,11 @@
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
       "dev": true
+    },
+    "setprototypeof": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
     "sha.js": {
       "version": "2.4.11",
@@ -16209,6 +17156,11 @@
           "dev": true
         }
       }
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "stream-browserify": {
       "version": "2.0.2",
@@ -16651,6 +17603,11 @@
       "resolved": "https://registry.npmjs.org/to-utf8/-/to-utf8-0.0.1.tgz",
       "integrity": "sha1-0Xrqcv8vujm55DYBvns/9y4ImFI="
     },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+    },
     "tough-cookie": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -16746,6 +17703,15 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
       "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw=="
     },
+    "type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      }
+    },
     "typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -16813,6 +17779,11 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "dev": true
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "unset-value": {
       "version": "1.0.0",
@@ -16956,6 +17927,11 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
     "uuid": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -16975,6 +17951,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "verror": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "ora": "^5.4.0",
     "puppeteer": "^8.0.0",
     "request": "^2.88.2",
+    "sponsorblock-api": "^0.1.3",
     "spotify-web-api-node": "^5.0.0",
     "yt-search": "^2.7.5",
     "ytdl-core": "^4.8.0"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "meow": "^9.0.0",
     "open": "^8.0.9",
     "ora": "^5.4.0",
+    "puppeteer": "^8.0.0",
     "request": "^2.88.2",
     "spotify-web-api-node": "^5.0.0",
     "yt-search": "^2.7.5",

--- a/package.json
+++ b/package.json
@@ -24,9 +24,11 @@
   "license": "ISC",
   "dependencies": {
     "axios": "^0.21.1",
+    "express": "^4.17.1",
     "ffmetadata": "^1.7.0",
     "fluent-ffmpeg": "^2.1.2",
     "meow": "^9.0.0",
+    "open": "^8.0.9",
     "ora": "^5.4.0",
     "request": "^2.88.2",
     "spotify-web-api-node": "^5.0.0",
@@ -41,6 +43,7 @@
     ]
   },
   "devDependencies": {
+    "eslint": "^7.26.0",
     "prettier": "^2.2.1",
     "xo": "^0.32.1"
   }

--- a/util/constants.js
+++ b/util/constants.js
@@ -1,4 +1,12 @@
 module.exports = {
+  AUTH: {
+    SCOPES: {
+      USERS_SAVED_PLAYLISTS: 'playlist-read-private',
+      USERS_TOP_TRACKS: 'user-top-read',
+      USERS_SAVED_TRACKS_ALBUMS: 'user-library-read',
+    },
+    STATE: 'some-random-state',
+  },
   INPUT_TYPES: {
     SONG: 'song',
     PLAYLIST: 'playlist',
@@ -9,18 +17,23 @@ module.exports = {
     SAVED_TRACKS: 'savedTracks',
     SAVED_PLAYLISTS: 'savedPlaylists',
   },
-  AUTH: {
-    SCOPES: {
-      USERS_SAVED_PLAYLISTS: 'playlist-read-private',
-      USERS_TOP_TRACKS: 'user-top-read',
-      USERS_SAVED_TRACKS_ALBUMS: 'user-library-read',
-    },
-    STATE: 'some-random-state',
+  FFMPEG: {
+    ASET: 'asetpts=PTS-STARTPTS'
   },
   MAX_LIMIT_DEFAULT: 50,
   SERVER: {
     PORT: 7654,
     HOST: 'localhost',
     CALLBACK_URI: '/callback',
+  },
+  SPONSOR_BLOCK: {
+    CATEGORIES: {
+      SPONSOR: 'sponsor',
+      INTRO: 'intro',
+      OUTRO: 'outro',
+      INTERACTION: 'interaction',
+      SELF_PROMO: 'selfpromo',
+      MUSIC_OFF_TOPIC: 'music_offtopic',
+    },
   },
 };

--- a/util/constants.js
+++ b/util/constants.js
@@ -1,0 +1,26 @@
+module.exports = {
+  INPUT_TYPES: {
+    SONG: 'song',
+    PLAYLIST: 'playlist',
+    ALBUM: 'album',
+    ARTIST: 'artist',
+    YOUTUBE: 'youtube',
+    SAVED_ALBUMS: 'savedAlbums',
+    SAVED_TRACKS: 'savedTracks',
+    SAVED_PLAYLISTS: 'savedPlaylists',
+  },
+  AUTH: {
+    SCOPES: {
+      USERS_SAVED_PLAYLISTS: 'playlist-read-private',
+      USERS_TOP_TRACKS: 'user-top-read',
+      USERS_SAVED_TRACKS_ALBUMS: 'user-library-read',
+    },
+    STATE: 'some-random-state',
+  },
+  MAX_LIMIT_DEFAULT: 50,
+  SERVER: {
+    PORT: 7654,
+    HOST: 'localhost',
+    CALLBACK_URI: '/callback',
+  },
+};

--- a/util/filters.js
+++ b/util/filters.js
@@ -1,8 +1,8 @@
 'use strict';
 
 module.exports = {
-  validateOutputSync: function (output) {
-    return output.replace(/[&\/\\#+$!"~%:*?<>{}\|]/g, '');
+  cleanOutputPath: function (output) {
+    return output ? output.replace(/[&\/\\#+$!"~.%:*?<>{}\|]/g, '') : '';
   },
   removeQuery: function (url) {
     return url.split('?')[0];

--- a/util/get-link.js
+++ b/util/get-link.js
@@ -18,13 +18,12 @@ function buildUrl(topResult) {
  */
 // this roughly equates to a max of 120mb
 const MAX_MINUTES = 60;
-const getLink = async songName => {
+const getLinks = async songName => {
   const tryLink = async () => {
     const result = await search(songName);
-    const topResult = result.videos
-      .find(video => video.seconds < (MAX_MINUTES * 60));
-    const youtubeLink = buildUrl(topResult);
-    return youtubeLink;
+    return result.videos.slice(0, 10)
+      .filter(video => video.seconds < (MAX_MINUTES * 60))
+      .map(video => buildUrl(video));
   };
   try {
     return await tryLink(songName);
@@ -37,4 +36,4 @@ const getLink = async songName => {
   }
 };
 
-module.exports = getLink;
+module.exports = getLinks;

--- a/util/get-songdata.js
+++ b/util/get-songdata.js
@@ -43,12 +43,25 @@ class SpotifyExtractor {
     return splits[splits.length - 1];
   }
 
+  async getSavedAlbums() {
+    console.log(await this.extractSavedAlbums());
+  }
+
+  async getSavedPlaylists() {
+    console.log(await this.extractSavedPlaylists());
+  }
+
+  async getSavedTracks() {
+    console.log(await this.extractSavedTracks());
+  }
+
   async extractTrack(trackId) {
     const trackData = await spotify.extractTrack(trackId);
     trackData.id = trackId;
     return trackData;
   }
 
+  //todo ditch these
   async extractPlaylist(playlistId) {
     return await spotify.extractPlaylist(playlistId);
   }
@@ -63,6 +76,18 @@ class SpotifyExtractor {
 
   async extractArtistAlbums(artistId) {
     return await spotify.extractArtistAlbums(artistId);
+  }
+
+  async extractSavedAlbums() {
+    return await spotify.extractSavedAlbums();
+  }
+
+  async extractSavedPlaylists() {
+    return await spotify.extractSavedPlaylists();
+  }
+
+  async extractSavedTracks() {
+    return await spotify.extractSavedTracks();
   }
 }
 

--- a/util/get-songdata.js
+++ b/util/get-songdata.js
@@ -7,35 +7,32 @@ class SpotifyExtractor {
   }
 
   async getTrack(url) {
-    return await this.extractTrack(this.getID(url));
+    return await spotify.extractTrack(this.getID(url));
   }
 
   async getAlbum(url) {
-    return await this.extractAlbum(this.getID(url));
+    return await spotify.extractAlbum(this.getID(url));
   }
 
   async getArtist(url) {
-    return await this.extractArtist(this.getID(url));
+    return await spotify.extractArtist(this.getID(url));
   }
 
   async getArtistAlbums(url) {
     const artistResult = await this.getArtist(url);
-    const albumsResult = await this.extractArtistAlbums(
+    const albumsResult = await spotify.extractArtistAlbums(
       artistResult.id,
     );
     const albumIds = albumsResult.map(album => album.id);
     let albumInfos = [];
     for (let x = 0; x < albumIds.length; x++) {
-      albumInfos.push(await this.extractAlbum(albumIds[x]));
+      albumInfos.push(await spotify.extractAlbum(albumIds[x]));
     }
-    return {
-      albums: albumInfos,
-      artist: artistResult,
-    };
+    return albumInfos;
   }
 
   async getPlaylist(url) {
-    return await this.extractPlaylist(this.getID(url));
+    return await spotify.extractPlaylist(this.getID(url));
   }
 
   getID(url) {
@@ -44,49 +41,26 @@ class SpotifyExtractor {
   }
 
   async getSavedAlbums() {
-    console.log(await this.extractSavedAlbums());
+    const albumsResult = await spotify.extractSavedAlbums();
+    const albumIds = albumsResult.map(album => album.id);
+    let albumInfos = [];
+    for (let x = 0; x < albumIds.length; x++) {
+      albumInfos.push(await spotify.extractAlbum(albumIds[x]));
+    }
+    return albumInfos;
   }
 
   async getSavedPlaylists() {
-    console.log(await this.extractSavedPlaylists());
+    const playlistsResults = await spotify.extractSavedPlaylists();
+    const playlistIds = playlistsResults.map(playlist => playlist.id);
+    let playlistInfos = [];
+    for (let x = 0; x < playlistIds.length; x++) {
+      playlistInfos.push(await spotify.extractPlaylist(playlistIds[x]));
+    }
+    return playlistInfos;
   }
 
   async getSavedTracks() {
-    console.log(await this.extractSavedTracks());
-  }
-
-  async extractTrack(trackId) {
-    const trackData = await spotify.extractTrack(trackId);
-    trackData.id = trackId;
-    return trackData;
-  }
-
-  //todo ditch these
-  async extractPlaylist(playlistId) {
-    return await spotify.extractPlaylist(playlistId);
-  }
-
-  async extractAlbum(albumId) {
-    return await spotify.extractAlbum(albumId);
-  }
-
-  async extractArtist(artistId) {
-    return await spotify.extractArtist(artistId);
-  }
-
-  async extractArtistAlbums(artistId) {
-    return await spotify.extractArtistAlbums(artistId);
-  }
-
-  async extractSavedAlbums() {
-    return await spotify.extractSavedAlbums();
-  }
-
-  async extractSavedPlaylists() {
-    return await spotify.extractSavedPlaylists();
-  }
-
-  async extractSavedTracks() {
     return await spotify.extractSavedTracks();
   }
 }

--- a/util/get-songdata.js
+++ b/util/get-songdata.js
@@ -41,11 +41,10 @@ class SpotifyExtractor {
   }
 
   async getSavedAlbums() {
-    const albumsResult = await spotify.extractSavedAlbums();
-    const albumIds = albumsResult.map(album => album.id);
+    const albums = await spotify.extractSavedAlbums();
     let albumInfos = [];
-    for (let x = 0; x < albumIds.length; x++) {
-      albumInfos.push(await spotify.extractAlbum(albumIds[x]));
+    for (let x = 0; x < albums.length; x++) {
+      albumInfos.push(await spotify.extractAlbum(albums[x].id));
     }
     return albumInfos;
   }


### PR DESCRIPTION
Creating this pr for initial eyes over the code,

current summary 

* added logic to try next download if 1 fails up to the top 10 links found
* added support for saved albums
* added support for saved playlists
* added support for saved tracks
* various simplifications and refactors
* added logic to always save a track in artist/album/song.mp3
* it will now auto login when a username and password is provided, this is required for non tty due to needing to auth, this is only needed when provided the --sa --st --sp flags due to needing user context. if username and password is not provided a browser is launched for manual user entry 
* tokens only last an hour so i don't think there's privacy concerns
* added support to save all tracks in the outputdir irrelevant of the folder/playlist/album contexts
* added support for users to override the config.js file to change the defaults to avoid adding to commands
* added support for auto removal of sponsors within videos

fixes #90 
fixes #91 
fixes #92 
fixes #93 
fixes #96 
fixes #101 
fixes #103