### PR TITLE
Feature/add support for episodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 *.mp3
 .vscode/
 Makefile
+.DS_STORE

--- a/README.md
+++ b/README.md
@@ -13,7 +13,11 @@ Get [FFMPEG](https://ffmpeg.org/download.html)
 
 #### spotifydl
 
-A simple commandline utility that allows you to download Spotify Songs,Playlist and Albums from Youtube.
+A simple commandline utility that allows you to download Spotify Songs, Shows, Episodes, Playlists and Albums from Youtube.
+
+PLEASE NOTE: 
+* The ability to find a video is dependent on the fact it is hosted on youtube, and even then there is a chance it is still incorrectly matched
+* Some items may only be available to spotify premium users, please be sure to provide a username and password when this is the case
 
 <hr>
 
@@ -73,6 +77,7 @@ $ spotifydl https://open.spotify.com/track/xyz
 | --es | takes extra search string/term to be used for youtube search |
 | --oo | enforces all downloaded songs in the output dir              |
 | --st | download spotify saved tracks                                |
+| --ss | download spotify saved shows                                 |
 | --sp | download spotify saved playlists                             |
 | --sa | download spotify saved albums                                |
 | -u   | spotify username (only needed in non tty)                    |

--- a/cli.js
+++ b/cli.js
@@ -14,26 +14,15 @@
   copies or substantial portions of the Software.
 */
 
-const { ffmpegSetup, getSpinner } = require('./lib/setup');
+const { startup } = require('./lib/setup');
+const { logFailure } = require('./util/log-helper');
 const Runner = require('./util/runner');
-const versionChecker = require('./util/version-checker');
 
-// setup ffmpeg
-ffmpegSetup(process.platform);
-const spinner = getSpinner();
-
-process.on('SIGINT', () => {
-  process.exit(1);
-});
-
-versionChecker();
-
+startup();
 try {
-  Runner.run().then(() =>
-    process.exit(0),
-  );
+  Runner.run().then(() => process.exit(0));
 } catch (error) {
-  spinner.fail('Something went wrong!');
+  logFailure('Something went wrong!');
   console.log(error);
   process.exit(1);
 }

--- a/config.js
+++ b/config.js
@@ -11,6 +11,7 @@ module.exports = {
     savedAlbums: false,
     savedPlaylists: false,
     savedTracks: false,
+    savedShows: false,
     outputOnly: false,
   },
 };

--- a/lib/api.js
+++ b/lib/api.js
@@ -2,7 +2,7 @@
 const SpotifyWebApi = require('spotify-web-api-node');
 const open = require('open');
 const puppeteer = require('puppeteer');
-const { cliInputs, getSpinner } = require('./setup');
+const { cliInputs } = require('./setup');
 const {
   AUTH: { SCOPES, STATE, REFRESH_ACCESS_TOKEN_SECONDS, TIMEOUT_RETRY },
   INPUT_TYPES,
@@ -14,6 +14,7 @@ const {
   },
 } = require('../util/constants');
 const express = require('express');
+const { logInfo, updateSpinner } = require('../util/log-helper');
 
 const spotifyApi = new SpotifyWebApi({
   clientId: 'acc6302297e040aeb6e4ac1fbdfd62c3',
@@ -29,6 +30,15 @@ const scopes = [
 
 let nextTokenRefreshTime;
 
+Object.defineProperty(Array.prototype, 'chunk', {
+  value: function (chunkSize) {
+    var R = [];
+    for (var i = 0; i < this.length; i += chunkSize)
+      R.push(this.slice(i, i + chunkSize));
+    return R;
+  },
+});
+
 module.exports = {
   spotifyApi,
   verifyCredentials: async function () {
@@ -37,8 +47,7 @@ module.exports = {
       nextTokenRefreshTime.setSeconds(
         nextTokenRefreshTime.getSeconds() + REFRESH_ACCESS_TOKEN_SECONDS,
       );
-      const spinner = getSpinner();
-      spinner.info('Generating new access token');
+      logInfo('Generating new access token');
       await this.checkCredentials();
     }
   },
@@ -48,15 +57,20 @@ module.exports = {
     } else {
       const {
         inputs,
+        username,
+        password,
       } = cliInputs();
 
       const requiresLogin = inputs.find(input =>
-        input.type == INPUT_TYPES.SAVED_ALBUMS ||
-        input.type == INPUT_TYPES.SAVED_PLAYLISTS ||
-        input.type == INPUT_TYPES.SAVED_TRACKS,
+        input.type == INPUT_TYPES.SONG.SAVED_ALBUMS ||
+        input.type == INPUT_TYPES.SONG.SAVED_PLAYLISTS ||
+        input.type == INPUT_TYPES.SONG.SAVED_TRACKS ||
+        input.type == INPUT_TYPES.EPISODE.SAVED_SHOWS,
       );
 
-      if (requiresLogin) {
+      const requestingLogin = username && password;
+
+      if (requiresLogin || requestingLogin) {
         await this.requestAuthorizedTokens();
       } else {
         await this.requestTokens();
@@ -142,7 +156,6 @@ module.exports = {
   // common wrapper for api calls
   // to have token verification and api throttling mitigation
   callSpotifyApi: async function (apiCall) {
-    const spinner = getSpinner();
     const maxRetries = 5;
     let tries = 1;
     let error;
@@ -154,8 +167,9 @@ module.exports = {
         return await apiCall();
       } catch (e) {
         error = e;
-        spinner.info(
-          `Got a spotify api error, Timing out for 5 minutes x ${tries}`,
+        logInfo(
+          `Got a spotify api error (${e})\n` +
+          `Timing out for 5 minutes x ${tries}`,
         );
         await new Promise(resolve => setTimeout(resolve, TIMEOUT_RETRY * 1000));
         tries++;
@@ -164,21 +178,18 @@ module.exports = {
     // if it still fails after all the timeouts and retries throw again
     throw new Error(error);
   },
-  extractTracks: async function (tracks) {
-    const spinner = getSpinner();
+  extractTracks: async function (trackIds) {
     const extractedTracks = [];
-    for (let x = 0; x < tracks.length; x++) {
-      spinner.info('extracting tracks ' +
-        `${x + 1}/${tracks.length}`);
-      extractedTracks.push(await this.extractTrack(tracks[x]));
+    const chunkedTracks = trackIds.chunk(20);
+    for (let x = 0; x < chunkedTracks.length; x++) {
+      updateSpinner('extracting track set ' +
+        `${x + 1}/${chunkedTracks.length}`);
+      const tracks = await this.callSpotifyApi(
+        async () => (await spotifyApi.getTracks(chunkedTracks[x])).body.tracks,
+      );
+      extractedTracks.push(...tracks);
     }
-    return extractedTracks;
-  },
-  extractTrack: async function (trackId) {
-    const track = await this.callSpotifyApi(
-      async () => (await spotifyApi.getTrack(trackId)).body,
-    );
-    return this.parseTrack(track);
+    return extractedTracks.map(track => this.parseTrack(track));
   },
   parseTrack: function (track) {
     return {
@@ -188,6 +199,16 @@ module.exports = {
       release_date: track.album.release_date,
       cover_url: track.album.images.map(image => image.url)[0],
       id: track.id,
+    };
+  },
+  parseEpisode: function (episode) {
+    return {
+      name: episode.name,
+      artist_name: episode.show.publisher,
+      album_name: episode.show.name,
+      release_date: episode.release_date,
+      cover_url: episode.images.map(image => image.url)[0],
+      id: episode.id,
     };
   },
   extractPlaylist: async function (playlistId) {
@@ -207,17 +228,20 @@ module.exports = {
           { limit: MAX_LIMIT_DEFAULT, offset: offset },
         )).body,
       );
+      if (!offset) {
+        updateSpinner(`extracting ${playlistData.total} tracks`);
+      }
       tracks.push(
-        ...playlistData.items.map(item => item.track),
+        ...playlistData.items,
       );
       offset += MAX_LIMIT_DEFAULT;
     } while (tracks.length < playlistData.total);
 
     return {
       name: `${playlistInfo.name} - ${playlistInfo.owner.display_name}`,
-      tracks: tracks
-        .filter(track => track)
-        .map(track => this.parseTrack(track)),
+      items: tracks
+        .filter(item => item.track)
+        .map(item => this.parseTrack(item.track)),
     };
   },
   extractAlbum: async function (albumId) {
@@ -237,13 +261,16 @@ module.exports = {
           { limit: MAX_LIMIT_DEFAULT, offset: offset },
         )).body,
       );
+      if (!offset) {
+        updateSpinner(`extracting ${albumTracks.total} tracks`);
+      }
       tracks.push(...albumTracks.items);
       offset += MAX_LIMIT_DEFAULT;
     } while (tracks.length < albumTracks.total);
 
     return {
       name: `${albumInfo.name} - ${albumInfo.label}`,
-      tracks: await this.extractTracks(
+      items: await this.extractTracks(
         tracks
           .filter(track => track)
           .map(track => track.id),
@@ -271,6 +298,9 @@ module.exports = {
           { limit: MAX_LIMIT_DEFAULT, offset: offset },
         )).body,
       );
+      if (!offset) {
+        updateSpinner(`extracting ${artistAlbums.total} albums`);
+      }
       albums.push(...artistAlbums.items);
       offset += MAX_LIMIT_DEFAULT;
     } while (albums.length < artistAlbums.total);
@@ -278,6 +308,67 @@ module.exports = {
     return albums.filter(
       album => album.artists.find(artist => artist.id == artistId),
     );
+  },
+  extractEpisodes: async function (episodeIds) {
+    const episodes = [];
+    let episodesResult;
+    const chunkedEpisodes = episodeIds.chunk(20);
+    for (let x = 0; x < chunkedEpisodes.length; x++) {
+      updateSpinner('extracting episode set ' +
+        `${x + 1}/${chunkedEpisodes.length}`);
+      episodesResult = await this.callSpotifyApi(
+        async () => (await spotifyApi.getEpisodes(
+          chunkedEpisodes[x],
+        )).body.episodes,
+      );
+      episodes.push(...episodesResult);
+    }
+    return episodes.map(episode => this.parseEpisode(episode));
+  },
+  extractShowEpisodes: async function (showId) {
+    const showInfo = await this.callSpotifyApi(
+      async () => (await spotifyApi.getShow(
+        showId,
+      )).body,
+    );
+    const episodes = [];
+    let offset = 0;
+    let showEpisodes;
+    do {
+      showEpisodes = await this.callSpotifyApi(
+        async () => (await spotifyApi.getShowEpisodes(
+          showId,
+          { limit: MAX_LIMIT_DEFAULT, offset: offset },
+        )).body,
+      );
+      if (!offset) {
+        updateSpinner(`extracting ${showEpisodes.total} episodes`);
+      }
+      episodes.push(...showEpisodes.items);
+      offset += MAX_LIMIT_DEFAULT;
+    } while (episodes.length < showEpisodes.total);
+    return {
+      name: `${showInfo.name} - ${showInfo.publisher}`,
+      items: await this.extractEpisodes(episodes.map(episode => episode.id)),
+    };
+  },
+  extractSavedShows: async function () {
+    const shows = [];
+    let offset = 0;
+    let savedShows;
+    do {
+      savedShows = await this.callSpotifyApi(
+        async () => (await spotifyApi.getMySavedShows(
+          { limit: MAX_LIMIT_DEFAULT, offset: offset },
+        )).body,
+      );
+      if (!offset) {
+        updateSpinner(`extracting ${savedShows.total} shows`);
+      }
+      shows.push(...savedShows.items);
+      offset += MAX_LIMIT_DEFAULT;
+    } while (shows.length < savedShows.total);
+    return shows.map(show => show.show);
   },
   extractSavedAlbums: async function () {
     const albums = [];
@@ -289,6 +380,9 @@ module.exports = {
           { limit: MAX_LIMIT_DEFAULT, offset: offset },
         )).body,
       );
+      if (!offset) {
+        updateSpinner(`extracting ${savedAlbums.total} albums`);
+      }
       albums.push(...savedAlbums.items);
       offset += MAX_LIMIT_DEFAULT;
     } while (albums.length < savedAlbums.total);
@@ -305,15 +399,16 @@ module.exports = {
           { limit: MAX_LIMIT_DEFAULT, offset: offset },
         )).body,
       );
+      if (!offset) {
+        updateSpinner(`extracting ${savedPlaylists.total} playlists`);
+      }
       playlists.push(...savedPlaylists.items);
       offset += MAX_LIMIT_DEFAULT;
     } while (playlists.length < savedPlaylists.total);
 
     return playlists;
   },
-
   extractSavedTracks: async function () {
-    const spinner = getSpinner();
     const tracks = [];
     let offset = 0;
     let savedTracks;
@@ -327,13 +422,13 @@ module.exports = {
         ...savedTracks.items.map(item => item.track),
       );
       offset += MAX_LIMIT_DEFAULT;
-      spinner.info('extracting tracks ' +
+      updateSpinner('extracting tracks ' +
         `${tracks.length}/${savedTracks.total}`);
     } while (tracks.length < savedTracks.total);
 
     return {
       name: 'Saved Tracks',
-      tracks: tracks
+      items: tracks
         .filter(track => track)
         .map(track => this.parseTrack(track)),
     };

--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -19,7 +19,9 @@ const {
     ASET,
   },
 } = require('../util/constants');
-const { getSpinner } = require('./setup');
+const {
+  logStart, updateSpinner, logInfo, logSuccess,
+} = require('../util/log-helper');
 
 const sponsorComplexFilter = async link => {
   const videoID = (new URLSearchParams((new URL(link)).search)).get('v');
@@ -66,16 +68,12 @@ const sponsorComplexFilter = async link => {
 };
 
 const progressFunction = (_, downloaded, total) => {
-  const spinner = getSpinner();
   const downloadedMb = (downloaded / 1024 / 1024).toFixed(2);
   const toBeDownloadedMb = (total / 1024 / 1024).toFixed(2);
   const isTTY = process.stdout.isTTY;
   const downloadText = `Downloaded ${downloadedMb}/${toBeDownloadedMb} MB`;
-  if (isTTY) {
-    spinner.text = downloadText;
-  }
-  else if (downloadedMb % 1 == 0 || toBeDownloadedMb == downloadedMb) {
-    spinner.info(downloadText);
+  if (isTTY || (downloadedMb % 1 == 0 || toBeDownloadedMb == downloadedMb)) {
+    updateSpinner(downloadText);
   }
 };
 
@@ -87,13 +85,12 @@ const progressFunction = (_, downloaded, total) => {
  * @param {string} output path/name of file to be downloaded(songname.mp3)
  */
 const downloader = async (youtubeLinks, output) => {
-  const spinner = getSpinner();
   let attemptCount = 0;
   let downloadSuccess = false;
   while ((attemptCount < youtubeLinks.length) && !downloadSuccess) {
     const link = youtubeLinks[attemptCount];
     const download = ytdl(link, youtubeDLConfig);
-    spinner.start(`Trying youtube link ${attemptCount + 1}...`);
+    logStart(`Trying youtube link ${attemptCount + 1}...`);
     download.on('progress', progressFunction);
     const complexFilter = await sponsorComplexFilter(link);
     const doDownload = (resolve, reject) => {
@@ -120,8 +117,8 @@ const downloader = async (youtubeLinks, output) => {
       await new Promise(doDownload);
       downloadSuccess = true;
     } catch (e) {
-      spinner.info(e.message);
-      spinner.info('Youtube error retrying download');
+      logInfo(e.message);
+      logInfo('Youtube error retrying download');
       attemptCount++;
     }
   }
@@ -130,7 +127,7 @@ const downloader = async (youtubeLinks, output) => {
     throw new Error('Failed to download anything');
   }
 
-  spinner.succeed('Download completed.');
+  logSuccess('Download completed.');
 };
 
 module.exports = downloader;

--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -3,7 +3,7 @@ const ffmetadata = require('ffmetadata');
 const fs = require('fs');
 const axios = require('axios').default;
 const ffmpeg = require('fluent-ffmpeg');
-const { getSpinner } = require('./setup');
+const { logSuccess } = require('../util/log-helper');
 
 const downloadAndSaveCover = async function (uri, filename) {
   const writer = fs.createWriteStream(filename);
@@ -16,7 +16,6 @@ const downloadAndSaveCover = async function (uri, filename) {
 };
 
 const mergeMetadata = async (output, songData) => {
-  const spinner = getSpinner();
   const coverFileName = output.slice(0, output.length - 3) + 'jpg';
 
   await downloadAndSaveCover(songData.cover_url, coverFileName);
@@ -69,7 +68,7 @@ const mergeMetadata = async (output, songData) => {
   fs.unlinkSync(output);
   fs.renameSync(tempPath, output);
   fs.unlinkSync(coverFileName);
-  spinner.succeed('Metadata Merged!\n');
+  logSuccess('Metadata Merged!\n');
 };
 
 module.exports = mergeMetadata;

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -5,53 +5,65 @@ const urlParser = require('../util/url-parser');
 const { removeQuery } = require('../util/filters');
 const { INPUT_TYPES } = require('../util/constants');
 const config = require('../config');
-const ora = require('ora');
+const versionChecker = require('../util/version-checker');
+const { logFailure } = require('../util/log-helper');
 
-const spinner = ora('Searching… Please be patient :)\n').start();
-
-module.exports = {
-  ffmpegSetup(platform_name) {
-    switch (platform_name) {
-      case 'win32': {
-        try {
-          const ffmpeg_paths = execSync('where ffmpeg');
-          if (ffmpeg_paths.includes('Could not find file')) {
-            process.env.PATH =
-              path.resolve(__dirname, 'bin;') + process.env.PATH;
-          }
-          break;
-        } catch (err) {
-          console
-            .log('Couldn\'t find ffmpeg. Please install https://ffmpeg.org');
+const ffmpegSetup = function (platform_name) {
+  switch (platform_name) {
+    case 'win32': {
+      try {
+        const ffmpeg_paths = execSync('where ffmpeg');
+        if (ffmpeg_paths.includes('Could not find file')) {
+          process.env.PATH =
+            path.resolve(__dirname, 'bin;') + process.env.PATH;
         }
         break;
+      } catch (err) {
+        logFailure(
+          'Couldn\'t find ffmpeg. Please install https://ffmpeg.org',
+        );
       }
-      case 'linux':
-      case 'android':
-      case 'darwin':
-
-        try {
-          const ffmpeg_paths = execSync('which ffmpeg');
-          if (ffmpeg_paths == null) {
-            console.error('ERROR: Cannot find ffmpeg! Install it first, \
-             why don\'t you read README.md on git!');
-            process.exit(-1);
-          }
-          else {
-            execSync('export FFMPEG_PATH=$(which ffmpeg)');
-          }
-
-          break;
-        } catch (error) {
-          console
-            .log('Couldn\'t find ffmpeg. Please install https://ffmpeg.org');
-        }
+      break;
     }
+    case 'linux':
+    case 'android':
+    case 'darwin':
+
+      try {
+        const ffmpeg_paths = execSync('which ffmpeg');
+        if (ffmpeg_paths == null) {
+          logFailure('ERROR: Cannot find ffmpeg! Install it first, \
+           why don\'t you read README.md on git!');
+          process.exit(-1);
+        }
+        else {
+          execSync('export FFMPEG_PATH=$(which ffmpeg)');
+        }
+
+        break;
+      } catch (error) {
+        logFailure(
+          'Couldn\'t find ffmpeg. Please install https://ffmpeg.org',
+        );
+      }
+  }
+};
+
+module.exports = {
+  ffmpegSetup,
+  startup() {
+    // setup ffmpeg
+    ffmpegSetup(process.platform);
+    process.on('SIGINT', () => {
+      process.exit(1);
+    });
+    versionChecker();
   },
   cliInputs() {
-    const loginRequired = (flags, input) => {
+    const loginRequired = (flags, _input) => {
       if ((flags.savedAlbums ||
         flags.savedPlaylists ||
+        flags.savedShows ||
         flags.savedSongs) && !process.stdout.isTTY
       ) {
         return true;
@@ -149,6 +161,18 @@ module.exports = {
           'eg. $ spotifydl -sa',
         ],
       },
+      savedShows: {
+        alias: 'ss',
+        type: 'boolean',
+        default: flagsConfig.savedShows,
+        helpText: [
+          '--saved-shows or --ss',
+          '* downloads a users saved shows',
+          '* username and password required for non TTY',
+          'eg. $ spotifydl -u "username" -p "password" -ss',
+          'eg. $ spotifydl -ss',
+        ],
+      },
       savedPlaylists: {
         alias: 'sp',
         type: 'boolean',
@@ -225,13 +249,16 @@ module.exports = {
     });
 
     if (inputFlags.savedAlbums) {
-      inputs.push({ type: INPUT_TYPES.SAVED_ALBUMS, url: null });
+      inputs.push({ type: INPUT_TYPES.SONG.SAVED_ALBUMS, url: null });
     }
     if (inputFlags.savedTracks) {
-      inputs.push({ type: INPUT_TYPES.SAVED_TRACKS, url: null });
+      inputs.push({ type: INPUT_TYPES.SONG.SAVED_TRACKS, url: null });
     }
     if (inputFlags.savedPlaylists) {
-      inputs.push({ type: INPUT_TYPES.SAVED_PLAYLISTS, url: null });
+      inputs.push({ type: INPUT_TYPES.SONG.SAVED_PLAYLISTS, url: null });
+    }
+    if (inputFlags.savedShows) {
+      inputs.push({ type: INPUT_TYPES.EPISODE.SAVED_SHOWS, url: null });
     }
 
     if (!inputs.length) {
@@ -248,8 +275,5 @@ module.exports = {
       username: inputFlags.username,
       password: inputFlags.password,
     };
-  },
-  getSpinner() {
-    return spinner;
   },
 };

--- a/util/constants.js
+++ b/util/constants.js
@@ -12,14 +12,21 @@ module.exports = {
     TIMEOUT_RETRY: 5 * 60,
   },
   INPUT_TYPES: {
-    SONG: 'song',
-    PLAYLIST: 'playlist',
-    ALBUM: 'album',
-    ARTIST: 'artist',
+    SONG: {
+      SONG: 'song',
+      PLAYLIST: 'playlist',
+      ALBUM: 'album',
+      ARTIST: 'artist',
+      SAVED_ALBUMS: 'savedAlbums',
+      SAVED_TRACKS: 'savedTracks',
+      SAVED_PLAYLISTS: 'savedPlaylists',
+    },
+    EPISODE: {
+      SHOW: 'show',
+      EPISODE: 'episode',
+      SAVED_SHOWS: 'savedShows',
+    },
     YOUTUBE: 'youtube',
-    SAVED_ALBUMS: 'savedAlbums',
-    SAVED_TRACKS: 'savedTracks',
-    SAVED_PLAYLISTS: 'savedPlaylists',
   },
   FFMPEG: {
     ASET: 'asetpts=PTS-STARTPTS',

--- a/util/get-link.js
+++ b/util/get-link.js
@@ -1,8 +1,12 @@
 'use strict';
 const { promisify } = require('util');
 const youtubeSearch = require('yt-search');
-const { YOUTUBE_SEARCH: { MAX_MINUTES } } = require('./constants');
+const {
+  YOUTUBE_SEARCH: { MAX_MINUTES },
+  INPUT_TYPES: { SONG },
+} = require('./constants');
 const stringSimilarity = require('string-similarity');
+const { logInfo } = require('./log-helper');
 const search = promisify(youtubeSearch);
 
 function buildUrl(topResult) {
@@ -14,30 +18,38 @@ function buildUrl(topResult) {
  * This function searches youtube for given songname 
  * and returns the link of topmost result
  *
- * @param {String} trackName name of song
+ * @param {String} itemName name of song
  * @param {String} albumName name of album
  * @param {String} artistName name of artist
  * @param {String} extraSearch extra search terms
+ * @param {String} type type of download being requested
  * @returns {String[]} youtube links
  */
-const getLinks = async ({ trackName, albumName, artistName, extraSearch }) => {
+const getLinks = async ({
+  itemName,
+  albumName,
+  artistName,
+  extraSearch,
+  type,
+}) => {
   const tryLink = async searchTerms => {
+    logInfo(`searching youtube with keywords "${searchTerms}"`);
     const result = await search(searchTerms);
+    const isSong = Object.values(SONG).includes(type);
     return result.videos.slice(0, 10)
-      .filter(video => (
-        video.seconds < (MAX_MINUTES * 60)) &&
-        (video.seconds > 0),
-      )
-      .map(video => buildUrl(video));
+      .filter(video => ((!isSong || (video.seconds < (MAX_MINUTES * 60))) &&
+        (video.seconds > 0)),
+      ).map(video => buildUrl(video));
   };
-  const similarity = stringSimilarity.compareTwoStrings(trackName, albumName);
+  const similarity = stringSimilarity.compareTwoStrings(itemName, albumName);
   let links = [];
   // to avoid duplicate song downloads
+  extraSearch = extraSearch ? ` ${extraSearch}` : '';
   if (similarity < 0.5) {
-    links = await tryLink(`${trackName} - ${albumName} ${extraSearch}`);
+    links = await tryLink(`${itemName} - ${albumName}${extraSearch}`);
   }
   if (!links.length) {
-    links = await tryLink(`${trackName} - ${artistName} ${extraSearch}`);
+    links = await tryLink(`${itemName} - ${artistName}${extraSearch}`);
   }
   return links;
 };

--- a/util/get-songdata.js
+++ b/util/get-songdata.js
@@ -7,7 +7,7 @@ class SpotifyExtractor {
   }
 
   async getTrack(url) {
-    return await spotify.extractTrack(this.getID(url));
+    return (await spotify.extractTracks([this.getID(url)]))[0];
   }
 
   async getAlbum(url) {
@@ -38,6 +38,23 @@ class SpotifyExtractor {
   getID(url) {
     const splits = url.split('/');
     return splits[splits.length - 1];
+  }
+
+  async getEpisode(url) {
+    return (await spotify.extractEpisodes([this.getID(url)]))[0];
+  }
+
+  async getShowEpisodes(url) {
+    return await spotify.extractShowEpisodes(this.getID(url));
+  }
+
+  async getSavedShows() {
+    const shows = await spotify.extractSavedShows();
+    let episodes = [];
+    for (let x = 0; x < shows.length; x++) {
+      episodes.push(await spotify.extractShowEpisodes(shows[x].id));
+    }
+    return episodes;
   }
 
   async getSavedAlbums() {

--- a/util/log-helper.js
+++ b/util/log-helper.js
@@ -1,0 +1,25 @@
+const ora = require('ora');
+
+const spinner = ora('Searching… Please be patient :)\n').start();
+
+module.exports = {
+  logInfo(message) {
+    spinner.info(message);
+  },
+  logStart(message) {
+    spinner.start(message);
+  },
+  logSuccess(message) {
+    spinner.succeed(message);
+  },
+  logFailure(message) {
+    spinner.fail(message);
+  },
+  updateSpinner(message) {
+    if (process.stdout.isTTY) {
+      spinner.text = message;
+    } else {
+      spinner.info(message);
+    }
+  },
+};

--- a/util/runner.js
+++ b/util/runner.js
@@ -9,142 +9,177 @@ const {
 const downloader = require('../lib/downloader');
 const cache = require('../lib/cache');
 const mergeMetadata = require('../lib/metadata');
-const { cliInputs, getSpinner } = require('../lib/setup');
+const { cliInputs } = require('../lib/setup');
 const SpotifyExtractor = require('./get-songdata');
+const { logSuccess, logInfo } = require('./log-helper');
 const { inputs, extraSearch, output, outputOnly } = cliInputs();
 
 module.exports = {
-  trackOutputDir: track => {
+  itemOutputDir: item => {
     const outputDir = path.normalize(output);
     return outputOnly ? outputDir : path.join(
       outputDir,
-      filter.cleanOutputPath(track.artist_name),
-      filter.cleanOutputPath(track.album_name),
+      filter.cleanOutputPath(item.artist_name),
+      filter.cleanOutputPath(item.album_name),
     );
   },
   downloadLoop: async function (list) {
-    const spinner = getSpinner();
-    const tracks = list.tracks;
-    const remainingTracks = tracks.filter(track => !track.cached);
-    const tracksCount = tracks.length;
-    const remainingTracksCount = remainingTracks.length;
-    const currentCount = tracksCount - remainingTracksCount + 1;
-    if (!remainingTracksCount) {
-      spinner.succeed(`All songs already downloaded for ${list.name}!\n`);
+    const items = list.items;
+    const remainingItems = items.filter(item => !item.cached);
+    const itemsCount = items.length;
+    const remainingItemsCount = remainingItems.length;
+    const currentCount = itemsCount - remainingItemsCount + 1;
+    if (!remainingItemsCount) {
+      logSuccess(`All items already downloaded for ${list.name}!\n`);
     } else {
-      const nextTrack = remainingTracks[0];
-      const trackDir = this.trackOutputDir(nextTrack);
-      const trackId = nextTrack.id;
-      const trackName = nextTrack.name;
-      const albumName = nextTrack.album_name;
-      const artistName = nextTrack.artist_name;
-      spinner.info(
+      const nextItem = remainingItems[0];
+      const itemDir = this.itemOutputDir(nextItem);
+      const itemId = nextItem.id;
+      const itemName = nextItem.name;
+      const albumName = nextItem.album_name;
+      const artistName = nextItem.artist_name;
+      logInfo(
         [
-          `${currentCount}/${tracksCount}`,
+          `${currentCount}/${itemsCount}`,
           `Artist: ${artistName}`,
           `Album: ${albumName}`,
-          `Song: ${trackName}`,
+          `Item: ${itemName}`,
         ].join('\n'),
       );
-      const ytLinks = nextTrack.URL ? [nextTrack.URL] : await getLinks(
+
+      const ytLinks = nextItem.URL ? [nextItem.URL] : await getLinks(
         {
-          trackName,
+          itemName,
           albumName,
           artistName,
           extraSearch,
+          type: list.type,
         },
       );
       if (ytLinks.length) {
         const output = path.resolve(
-          trackDir,
-          `${filter.cleanOutputPath(trackName)}.mp3`,
+          itemDir,
+          `${filter.cleanOutputPath(itemName)}.mp3`,
         );
         await downloader(ytLinks, output);
-        await mergeMetadata(output, nextTrack);
-        cache.writeId(trackDir, trackId);
+        await mergeMetadata(output, nextItem);
+        cache.writeId(itemDir, itemId);
       }
       // we mark as cached to continue
-      list.tracks = list.tracks.map(track => {
-        if (track.id == trackId) {
-          track.cached = true;
+      list.items = list.items.map(item => {
+        if (item.id == itemId) {
+          item.cached = true;
         }
-        return track;
+        return item;
       });
       await this.downloadLoop(list);
     }
   },
   downloadList: async function (list) {
-    const spinner = getSpinner();
     list.name = list.name.replace('/', '-');
-    spinner.info(`Downloading: ${list.name}`);
-    spinner.info(`Total Songs: ${list.tracks.length}`);
-    list.tracks = list.tracks.map(track => {
-      track.cached = cache.findId(track.id, this.trackOutputDir(track));
-      return track;
+    logInfo(`Downloading: ${list.name}`);
+    logInfo(`Total Items: ${list.items.length}`);
+    list.items = list.items.map(item => {
+      item.cached = cache.findId(item.id, this.itemOutputDir(item));
+      return item;
     });
     await this.downloadLoop(list);
   },
   run: async function () {
     const spotifyExtractor = new SpotifyExtractor();
-    const spinner = getSpinner();
     for (const input of inputs) {
+      logInfo(`Starting processing of ${input.type} (${input.url})`);
       const URL = input.url;
       switch (input.type) {
-        case INPUT_TYPES.SONG: {
+        case INPUT_TYPES.SONG.SONG: {
           const track = await spotifyExtractor.getTrack(URL);
           await this.downloadList({
-            tracks: [
+            items: [
               track,
             ],
             name: `${track.name} ${track.artist_name}`,
+            type: input.type,
           });
           break;
         }
-        case INPUT_TYPES.PLAYLIST: {
-          await this.downloadList(
-            await spotifyExtractor.getPlaylist(URL),
-          );
+        case INPUT_TYPES.SONG.PLAYLIST: {
+          const list = await spotifyExtractor.getPlaylist(URL);
+          list.type = input.type;
+          await this.downloadList(list);
           break;
         }
-        case INPUT_TYPES.ALBUM: {
-          await this.downloadList(
-            await spotifyExtractor.getAlbum(URL),
-          );
+        case INPUT_TYPES.SONG.ALBUM: {
+          const list = await spotifyExtractor.getAlbum(URL);
+          list.type = input.type;
+          await this.downloadList(await this.downloadList(list));
           break;
         }
-        case INPUT_TYPES.ARTIST: {
+        case INPUT_TYPES.SONG.ARTIST: {
           const artistAlbumInfos = await spotifyExtractor.getArtistAlbums(URL);
           for (let x = 0; x < artistAlbumInfos.length; x++) {
-            spinner.info(`Starting album ${x + 1}/${artistAlbumInfos.length}`);
-            await this.downloadList(artistAlbumInfos[x]);
+            const list = artistAlbumInfos[x];
+            list.type = input.type;
+            logInfo(`Starting album ${x + 1}/${artistAlbumInfos.length}`);
+            await this.downloadList(list);
           }
           break;
         }
-        case INPUT_TYPES.SAVED_ALBUMS: {
+        case INPUT_TYPES.EPISODE.EPISODE: {
+          const episode = await spotifyExtractor.getEpisode(URL);
+          await this.downloadList({
+            items: [
+              episode,
+            ],
+            name: `${episode.name} ${episode.album_name}`,
+            type: input.type,
+          });
+          break;
+        }
+        case INPUT_TYPES.EPISODE.SHOW: {
+          const list = await spotifyExtractor.getShowEpisodes(URL);
+          list.type = input.type;
+          await this.downloadList(list);
+          break;
+        }
+        case INPUT_TYPES.EPISODE.SAVED_SHOWS: {
+          const savedShowsInfo = await spotifyExtractor.getSavedShows();
+          for (let x = 0; x < savedShowsInfo.length; x++) {
+            logInfo(`Starting show ${x + 1}/${savedShowsInfo.length}`);
+            await this.downloadList(savedShowsInfo[x]);
+          }
+          break;
+        }
+        case INPUT_TYPES.SONG.SAVED_ALBUMS: {
           const savedAlbumsInfo = await spotifyExtractor.getSavedAlbums();
           for (let x = 0; x < savedAlbumsInfo.length; x++) {
-            spinner.info(`Starting album ${x + 1}/${savedAlbumsInfo.length}`);
-            await this.downloadList(savedAlbumsInfo[x]);
+            const list = savedAlbumsInfo[x];
+            list.type = input.type;
+            logInfo(`Starting album ${x + 1}/${savedAlbumsInfo.length}`);
+            await this.downloadList(list);
           }
           break;
         }
-        case INPUT_TYPES.SAVED_PLAYLISTS: {
+        case INPUT_TYPES.SONG.SAVED_PLAYLISTS: {
           const savedPlaylistsInfo = await spotifyExtractor.getSavedPlaylists();
           for (let x = 0; x < savedPlaylistsInfo.length; x++) {
-            spinner.info(
+            const list = savedPlaylistsInfo[x];
+            list.type = input.type;
+            logInfo(
               `Starting playlist ${x + 1}/${savedPlaylistsInfo.length}`,
             );
-            await this.downloadList(savedPlaylistsInfo[x]);
+            await this.downloadList(list);
           }
           break;
         }
-        case INPUT_TYPES.SAVED_TRACKS: {
-          await this.downloadList(await spotifyExtractor.getSavedTracks());
+        case INPUT_TYPES.SONG.SAVED_TRACKS: {
+          const list = await spotifyExtractor.getSavedTracks();
+          list.type = input.type;
+          await this.downloadList(list);
           break;
         }
         case INPUT_TYPES.YOUTUBE: {
           await this.downloadList({
-            tracks: [
+            items: [
               {
                 name: URL,
                 artist_name: '',
@@ -159,11 +194,13 @@ module.exports = {
               },
             ],
             name: URL,
+            type: input.type,
           });
           break;
         }
         default: {
-          throw new Error('Invalid URL type');
+          throw new Error(`Invalid URL type (${input.type}), ` +
+            'Please visit github and make a request to support this type');
         }
       }
     }

--- a/util/url-parser.js
+++ b/util/url-parser.js
@@ -15,6 +15,12 @@ const parser = inputUrl => {
   else if (inputUrl.includes('/artist/')) {
     return 'artist';
   }
+  else if (inputUrl.includes('/show/')) {
+    return 'show';
+  }
+  else if (inputUrl.includes('/episode/')) {
+    return 'episode';
+  }
   else {
     return new Error('Invalid spotify URL');
   }


### PR DESCRIPTION
#  Support for episodes/ shows

## Details
* added support for single episodes, shows episodes and saved episodes
* updated the token request to always use user/pass token when provided instead of only when searching saved items due to some items restricted to premium users only
* reworked episodes to extract in chucks of 20 instead of individually to reduce calls to spotify
* refactored startup logic into its own function
* refactored logging to be in its own file
* ignore max video length check when searching episodes

## Testing
tested all types of videos

## Checklist
[x] Ran eslint/prettier formatting
[x] Tests are passing (no tests yet)
[x] Feature is considered complete

## Issues this resolves
fixes #112 