### PR TITLE
flag for manual logic option

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,22 +71,23 @@ $ spotifydl https://open.spotify.com/track/xyz
 ```
 
 #### Options
-| Flag  | Long Flag         | Usage                                                                 |
-| ----- | ----------------- | --------------------------------------------------------------------- |
-| --o   | --output          | takes valid output path argument                                      |
-| --es  | --extra-search    | takes extra search string/term to be used for youtube search          |
-| --oo  | --output-only     | enforces all downloaded songs in the output dir                       |
-| --st  | --saved-tracks    | download spotify saved tracks                                         |
-| --ss  | --saved-songs     | download spotify saved shows                                          |
-| --sp  | --saved-playlists | download spotify saved playlists                                      |
-| --sa  | --saved-albums    | download spotify saved albums                                         |
-| --u   | --username        | spotify username (only needed in non tty)                             |
-| --p   | --password        | spotify password (only needed in non tty)                             |
-| --cf  | --cache-file      | takes valid output file name path argument                            |
-| --dr  | --download-report | output a download report of what files failed                         |
-| --cof | --cookie-file     | takes valid file name path argument to a txt file for youtube cookies |
-| --v   | --version         | returns current version                                               |
-| --h   | --help            | outputs help text                                                     |
+| Flag  | Long Flag         | Usage                                                                   |
+| ----- | ----------------- | ----------------------------------------------------------------------- |
+| --o   | --output          | takes valid output path argument                                        |
+| --es  | --extra-search    | takes extra search string/term to be used for youtube search            |
+| --oo  | --output-only     | enforces all downloaded songs in the output dir                         |
+| --st  | --saved-tracks    | download spotify saved tracks                                           |
+| --ss  | --saved-songs     | download spotify saved shows                                            |
+| --sp  | --saved-playlists | download spotify saved playlists                                        |
+| --sa  | --saved-albums    | download spotify saved albums                                           |
+| --l   | --login           | Requests a login in an external window (non tty should use --u and --p) |
+| --u   | --username        | spotify username for headless long                                      |
+| --p   | --password        | spotify password                                                        |
+| --cf  | --cache-file      | takes valid output file name path argument                              |
+| --dr  | --download-report | output a download report of what files failed                           |
+| --cof | --cookie-file     | takes valid file name path argument to a txt file for youtube cookies   |
+| --v   | --version         | returns current version                                                 |
+| --h   | --help            | outputs help text                                                       |
 <hr>
 
 ## Notes

--- a/config.js
+++ b/config.js
@@ -8,6 +8,7 @@ export default {
     downloadReport: true,
     output: process.cwd(),
     extraSearch: '',
+    login: false,
     password: '',
     username: '',
     savedAlbums: false,
@@ -16,4 +17,9 @@ export default {
     savedShows: false,
     outputOnly: false,
   },
+  spotifyApi: {
+    clientId: 'acc6302297e040aeb6e4ac1fbdfd62c3',
+    clientSecret: '0e8439a1280a43aba9a5bc0a16f3f009',
+  },
+  isTTY: process.stdout.isTTY,
 };

--- a/lib/api.js
+++ b/lib/api.js
@@ -357,6 +357,7 @@ export async function extractEpisodes(episodeIds) {
         chunkedEpisodes[x],
       )).body.episodes,
     );
+    episodesResult = episodesResult.filter(episode => episode);
     episodes.push(...episodesResult);
   }
   return episodes.map(episode => parseEpisode(episode));

--- a/lib/api.js
+++ b/lib/api.js
@@ -3,8 +3,16 @@ import open from 'open';
 import express from 'express';
 import puppeteer from 'puppeteer';
 import { cliInputs } from './setup.js';
+import Config from '../config.js';
 import Constants from '../util/constants.js';
 import { logInfo, logFailure } from '../util/log-helper.js';
+
+const {
+  spotifyApi: {
+    clientId,
+    clientSecret,
+  },
+} = Config;
 
 const {
   AUTH: {
@@ -21,8 +29,8 @@ const {
 } = Constants;
 
 const spotifyApi = new SpotifyWebApi({
-  clientId: 'acc6302297e040aeb6e4ac1fbdfd62c3',
-  clientSecret: '0e8439a1280a43aba9a5bc0a16f3f009',
+  clientId,
+  clientSecret,
   redirectUri: `http://${HOST}:${PORT}${CALLBACK_URI}`,
 });
 
@@ -62,6 +70,7 @@ const checkCredentials = async () => {
       inputs,
       username,
       password,
+      login,
     } = cliInputs();
 
     const requiresLogin = inputs.find(input =>
@@ -71,7 +80,7 @@ const checkCredentials = async () => {
       input.type == INPUT_TYPES.EPISODE.SAVED_SHOWS,
     );
 
-    const requestingLogin = username && password;
+    const requestingLogin = (username && password) || login;
 
     if (requiresLogin || requestingLogin) {
       await requestAuthorizedTokens();
@@ -105,6 +114,10 @@ const requestAuthorizedTokens = async () => {
   );
 
   let browser = null;
+
+  logInfo(
+    'Performing Spotify Auth Please Wait...',
+  );
 
   if (autoLogin) {
     browser = await puppeteer.launch({

--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -10,6 +10,7 @@ import {
   logStart, updateSpinner, logInfo, logSuccess,
 } from '../util/log-helper.js';
 
+const { youtubeDLConfig, isTTY } = Config;
 const sponsorBlock = new SponsorBlock(1234);
 const {
   SPONSOR_BLOCK: {
@@ -75,7 +76,6 @@ const sponsorComplexFilter = async link => {
 const progressFunction = (_, downloaded, total) => {
   const downloadedMb = (downloaded / 1024 / 1024).toFixed(2);
   const toBeDownloadedMb = (total / 1024 / 1024).toFixed(2);
-  const isTTY = process.stdout.isTTY;
   const downloadText = `Downloaded ${downloadedMb}/${toBeDownloadedMb} MB`;
   if (isTTY || (downloadedMb % 1 == 0 || toBeDownloadedMb == downloadedMb)) {
     updateSpinner(downloadText);
@@ -83,7 +83,6 @@ const progressFunction = (_, downloaded, total) => {
 };
 
 const getYoutubeDLConfig = () => {
-  const config = Config.youtubeDLConfig;
   const { cookieFile } = cliInputs();
   if (fs.existsSync(cookieFile)) {
     const cookieFileContents = fs
@@ -97,13 +96,13 @@ const getYoutubeDLConfig = () => {
         return cookie;
       }, '')
       .trim();
-    config.requestOptions = {
+    youtubeDLConfig.requestOptions = {
       headers: {
         Cookie: cookieFileContents,
       },
     };
   }
-  return config;
+  return youtubeDLConfig;
 };
 
 /**

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -63,7 +63,7 @@ export function cliInputs() {
     if ((flags.savedAlbums ||
       flags.savedPlaylists ||
       flags.savedShows ||
-      flags.savedSongs) && !process.stdout.isTTY
+      flags.savedSongs) && !Config.isTTY
     ) {
       return true;
     }
@@ -143,6 +143,17 @@ export function cliInputs() {
             to the song search on youtube',
         '* with playlist and albums it will concat with each song.',
         'eg. $ spotifydl <url> --extra-search "lyrics"',
+      ],
+    },
+    login: {
+      alias: 'l',
+      type: 'boolean',
+      default: flagsConfig.login,
+      helpText: [
+        '--login or -l',
+        '* will perform a spotify login in an external window for permission',
+        '* allows spotify premium access restricted things',
+        'eg. $ spotifydl --l',
       ],
     },
     username: {
@@ -302,6 +313,7 @@ export function cliInputs() {
     cookieFile: inputFlags.cookieFile,
     downloadReport: inputFlags.downloadReport,
     outputOnly: inputFlags.outputOnly,
+    login: inputFlags.login,
     username: inputFlags.username,
     password: inputFlags.password,
   };

--- a/util/log-helper.js
+++ b/util/log-helper.js
@@ -1,4 +1,5 @@
 import ora from 'ora';
+import Config from '../config.js';
 
 const spinner = ora('Searching… Please be patient :)\n').start();
 
@@ -19,7 +20,7 @@ export function logFailure(message) {
 }
 
 export function updateSpinner(message) {
-  if (process.stdout.isTTY) {
+  if (Config.isTTY) {
     spinner.text = message;
   } else {
     spinner.info(message);

--- a/util/runner.js
+++ b/util/runner.js
@@ -158,13 +158,20 @@ const run = async () => {
       }
       case INPUT_TYPES.EPISODE.EPISODE: {
         const episode = await getEpisode(URL);
-        lists.push({
-          items: [
-            episode,
-          ],
-          name: `${episode.name} ${episode.album_name}`,
-          type: input.type,
-        });
+        if (episode) {
+          lists.push({
+            items: [
+              episode,
+            ],
+            name: `${episode.name} ${episode.album_name}`,
+            type: input.type,
+          });
+        } else {
+          logFailure(
+            'Failed to find episode, you may need to use auth',
+          );
+        }
+
         break;
       }
       case INPUT_TYPES.EPISODE.SHOW: {


### PR DESCRIPTION
<!-- **IMPORTANT: Please do not create a Pull Request without creating an issue first.** -->
<!-- *Any change may need to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.* -->
# Title
hey @SwapnilSoni1999 basically in the ticket mentioned below there is a requirement to allow users to force auth for some items i.e podcasts. This pr adds a flag for allow the manual logic prompt (alternative to -u + -p headless login).

* Added logic to support a `--l` flag, this flag forces your token through authorized, similar to providing username + password. but serves the manual window 
* added a check for when episodes return null #138 
* added readme section for the above "issue"
* various minor refactors

## Checklist
[x] Ran eslint/prettier formatting
[x] Tests are passing (no tests yet)
[x] Feature is considered complete

