### PR TITLE
Fix #171

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,23 +75,23 @@ $ spotifydl https://open.spotify.com/track/xyz
 ```
 
 #### Options
-| Flag  | Long Flag         | Usage                                                                                |
-| ----- | ----------------- | ------------------------------------------------------------------------------------ |
-| --o   | --output          | takes valid output path argument                                                     |
-| --es  | --extra-search    | takes extra search string/term to be used for youtube search                         |
-| --oo  | --output-only     | enforces all downloaded songs in the output dir                                      |
-| --st  | --saved-tracks    | download spotify saved tracks                                                        |
-| --ss  | --saved-songs     | download spotify saved shows                                                         |
-| --sp  | --saved-playlists | download spotify saved playlists                                                     |
-| --sa  | --saved-albums    | download spotify saved albums                                                        |
-| --l   | --login           | Requests a login in an external window (non tty should use --u and --p)              |
-| --u   | --username        | spotify username for headless long (Note: you must use --login once to grant access) |
-| --p   | --password        | spotify password                                                                     |
-| --cf  | --cache-file      | takes valid output file name path argument                                           |
-| --dr  | --download-report | output a download report of what files failed                                        |
-| --cof | --cookie-file     | takes valid file name path argument to a txt file for youtube cookies                |
-| --v   | --version         | returns current version                                                              |
-| --h   | --help            | outputs help text                                                                    |
+| Flag  | Long Flag         | Usage                                                                                                   |
+| ----- | ----------------- | ------------------------------------------------------------------------------------------------------- |
+| --o   | --output          | takes valid output path argument                                                                        |
+| --es  | --extra-search    | takes extra search string/term to be used for youtube search                                            |
+| --oo  | --output-only     | enforces all downloaded songs in the output dir                                                         |
+| --st  | --saved-tracks    | download spotify saved tracks                                                                           |
+| --ss  | --saved-songs     | download spotify saved shows                                                                            |
+| --sp  | --saved-playlists | download spotify saved playlists                                                                        |
+| --sa  | --saved-albums    | download spotify saved albums                                                                           |
+| --l   | --login           | Requests a login in an external window (non tty should use --u and --p) (Docker without -it is non tty) |
+| --u   | --username        | spotify username for headless long (Note: you must use --login once to grant access)                    |
+| --p   | --password        | spotify password                                                                                        |
+| --cf  | --cache-file      | takes valid output file name path argument                                                              |
+| --dr  | --download-report | output a download report of what files failed                                                           |
+| --cof | --cookie-file     | takes valid file name path argument to a txt file for youtube cookies                                   |
+| --v   | --version         | returns current version                                                                                 |
+| --h   | --help            | outputs help text                                                                                       |
 <hr>
 
 ## Notes

--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -5,14 +5,25 @@ import ffmpeg from 'fluent-ffmpeg';
 import { logSuccess } from '../util/log-helper.js';
 import Constants from '../util/constants.js';
 
-const downloadAndSaveCover = async function (uri, filename) {
-  const writer = fs.createWriteStream(filename);
-  const cover = await axios.default({
-    method: 'GET',
-    url: uri,
-    responseType: 'stream',
+const downloadAndSaveCover = function (uri, filename) {
+  return new Promise(async (resolve, reject) => {
+    const cover = await axios.default({
+      method: 'GET',
+      url: uri,
+      responseType: 'stream',
+    });
+    const ffmpegCommand = ffmpeg();
+    ffmpegCommand
+      .on('error', e => {
+        reject(e);
+      })
+      .on('end', () => {
+        resolve();
+      })
+      .input(cover.data)
+      .save(`${filename}`)
+      .format('jpg');
   });
-  cover.data.pipe(writer);
 };
 
 const mergeMetadata = async (output, songData) => {

--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -4,6 +4,9 @@ import axios from 'axios';
 import ffmpeg from 'fluent-ffmpeg';
 import { logSuccess } from '../util/log-helper.js';
 import Constants from '../util/constants.js';
+import {
+  logInfo,
+} from '../util/log-helper.js';
 
 const downloadAndSaveCover = function (uri, filename) {
   return new Promise(async (resolve, reject) => {
@@ -32,7 +35,25 @@ const mergeMetadata = async (output, songData) => {
   if (!coverURL) {
     coverURL = Constants.YOUTUBE_SEARCH.GENERIC_IMAGE;
   }
-  await downloadAndSaveCover(coverURL, coverFileName);
+
+  try {
+    await downloadAndSaveCover(coverURL, coverFileName);
+  } catch (_e) {
+    // image is corrupt or not available try again
+    logInfo('Album Thumbnail corrupt attempting again');
+    try {
+      await downloadAndSaveCover(coverURL, coverFileName);
+    } catch (_e2) {
+      // if it fails again just fallback to generic image
+      logInfo(
+        'Album Thumbnail corrupt for second time fallback to generic image',
+      );
+      await downloadAndSaveCover(
+        Constants.YOUTUBE_SEARCH.GENERIC_IMAGE, coverFileName,
+      );
+    }
+  }
+
   const metadata = {
     artist: songData.artists,
     album: songData.album_name,

--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -48,10 +48,14 @@ const mergeMetadata = async (output, songData) => {
       logInfo(
         'Album Thumbnail corrupt for second time fallback to generic image',
       );
-      await downloadAndSaveCover(
-        Constants.YOUTUBE_SEARCH.GENERIC_IMAGE, coverFileName,
-      );
     }
+  }
+
+  if (!fs.existsSync(coverFileName)) {
+    await downloadAndSaveCover(
+      'https://i.ibb.co/PN87XDk/unknown.jpg',
+      coverFileName,
+    );
   }
 
   const metadata = {


### PR DESCRIPTION
# Title
Fix problem with song covers being corrupt.

## Details
Instead of just downloading the cover, it passes it though ffmpeg to ensure the format is jpg.

## Testing
Downloaded the same playlist of #171 and running ffprobe didn't return any problems, also no apparent problems in file managers.

## Checklist
[X] Ran eslint/prettier formatting
[ ] Tests are passing (no tests yet)
[X] Feature is considered complete

## Issues this resolves
fixes and closes #171
