### PR TITLE
filter out null objects

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -205,7 +205,7 @@ const callSpotifyApi = async function (apiCall) {
 };
 
 export async function extractTracks(trackIds) {
-  const extractedTracks = [];
+  let extractedTracks = [];
   const chunkedTracks = trackIds.chunk(20);
   for (let x = 0; x < chunkedTracks.length; x++) {
     logInfo('extracting track set ' +
@@ -215,9 +215,10 @@ export async function extractTracks(trackIds) {
     );
     extractedTracks.push(...tracks);
   }
-  const audioFeatures = await extractTrackAudioFeatures(
+  extractedTracks = extractedTracks.filter(x => x);
+  const audioFeatures = (await extractTrackAudioFeatures(
     extractedTracks.map(track => track.id),
-  );
+  )).filter(x => x);
   return extractedTracks.map(track => parseTrack(track, audioFeatures));
 }
 


### PR DESCRIPTION
# Title
Filter out null values to avoid looping null objects

## Issues this resolves
fixes #201 