### PR TITLE
Fix request for AudioFeatures being too large

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -503,11 +503,11 @@ export async function extractSavedTracks() {
 export async function extractTrackAudioFeatures(trackIds) {
   let audioFeatures = [];
   for(let chunk of trackIds.chunk(MAX_LIMIT_DEFAULT)) {
-    audioFeatures.push(await callSpotifyApi(
+    audioFeatures.push(...(await callSpotifyApi(
       async () => (await spotifyApi.getAudioFeaturesForTracks(
         chunk,
       )).body.audio_features,
-    ));
+    )));
   }
   return audioFeatures;
 }

--- a/lib/api.js
+++ b/lib/api.js
@@ -501,9 +501,13 @@ export async function extractSavedTracks() {
 }
 
 export async function extractTrackAudioFeatures(trackIds) {
-  return await callSpotifyApi(
-    async () => (await spotifyApi.getAudioFeaturesForTracks(
-      trackIds,
-    )).body.audio_features,
-  );
+  let audioFeatures = [];
+  for(let chunk of trackIds.chunk(MAX_LIMIT_DEFAULT)) {
+    audioFeatures.push(await callSpotifyApi(
+      async () => (await spotifyApi.getAudioFeaturesForTracks(
+        chunk,
+      )).body.audio_features,
+    ));
+  }
+  return audioFeatures;
 }


### PR DESCRIPTION
# Title
Solves the 502 response when downloading large collection of saved tracks.

## Details
Extracting audio features using chunks of size MAX_LIMIT_DEFAULT (50) instead of searching the whole list in one request.

## Testing
Being able to download my saved tracks

## Checklist
[X] Ran eslint/prettier formatting
[X] Tests are passing (no tests yet)
[X] Feature is considered complete

## Issues this resolves
fixes #212 