### PR TITLE
Add logic to support a templatable filename 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .vscode/
 Makefile
 .DS_STORE
+*.mp3

--- a/config.js
+++ b/config.js
@@ -18,6 +18,7 @@ export default {
     outputOnly: false,
     downloadLyrics: false,
     searchFormat: '',
+    outputFormat: '{artistName}___{albumName}___{itemName}',
     exclusionFilters: '',
   },
   spotifyApi: {

--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -145,7 +145,7 @@ const downloader = async (youtubeLinks, output) => {
     try {
       await new Promise(doDownload);
       downloadSuccess = true;
-      logSuccess('Download completed.');
+      logSuccess(`Download completed (${output}).`);
     } catch (e) {
       logInfo(e.message);
       logInfo('Youtube error retrying download');

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -265,6 +265,21 @@ export function cliInputs() {
         'eg. $ spotifydl --sf  "something {itemName} - {albumName} anyrandomextrastring"',
       ],
     },
+    outputFormat: {
+      alias: 'of',
+      default: flagsConfig.outputFormat,
+      type: 'string',
+      helpText: [
+        '--output-format or --of',
+        '* allows for a user provided template to be used for the output filename',
+        '* supports the following contexts `albumName`, `artistName`,`itemName`',
+        '* note `itemName` references the search i.e track/show',
+        '* note the output argument is prepended to this argument',
+        '* note ___ is used to signify a directory',
+        '* if not provided will fallback to "{artistName}___{albumName}___{itemName}"',
+        'eg. $ spotifydl --of  "some_extra_dir___{artistName}___{albumName}___{itemName}"',
+      ],
+    },
     exclusionFilters: {
       alias: "ef",
       default: flagsConfig.exclusionFilters,
@@ -355,5 +370,6 @@ export function cliInputs() {
     username: inputFlags.username,
     password: inputFlags.password,
     downloadLyrics: inputFlags.downloadLyrics,
+    outputFormat: inputFlags.outputFormat,
   };
 }

--- a/util/format-generators.js
+++ b/util/format-generators.js
@@ -1,0 +1,26 @@
+import Constants from './constants.js';
+
+const {
+  YOUTUBE_SEARCH: { VALID_CONTEXTS },
+} = Constants;
+
+export function generateTemplateString(
+  itemName,
+  albumName,
+  artistName,
+  format,
+) {
+  const contexts = format.match(/(?<=\{).+?(?=\})/g);
+  const invalidContexts = contexts.filter(
+    context => !VALID_CONTEXTS.includes(context),
+  );
+  if (invalidContexts.length > 0 || !contexts.length) {
+    throw new Error(`Invalid search contexts: ${invalidContexts}`);
+  }
+
+  contexts.forEach(
+    context => (format = format.replace(`{${context}}`, eval(context))),
+  );
+
+  return format;
+}


### PR DESCRIPTION

# Title
As one user has requested a way to provide a template to adjust the filename used, simply refactored the current logic for youtube searching based on details to also be used to allow for a generic template when saving the filename

![image](https://github.com/SwapnilSoni1999/spotify-dl/assets/5182053/a36a03ed-c819-471f-b7c5-5af95d2823ee)

![image](https://github.com/SwapnilSoni1999/spotify-dl/assets/5182053/46439f50-50f2-4861-996a-5301954375dc)



## Issues this resolves
fixes #229