### PR TITLE
Update version-checker.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swapnilsoni1999/spotify-dl",
   "productName": "Spotify Downloader",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Spotify Songs, Playlist & Album Downloader",
   "main": "app.js",
   "bin": {

--- a/util/version-checker.js
+++ b/util/version-checker.js
@@ -8,6 +8,7 @@ const checkVersion = async () => {
     );
   } catch (_e) {
      console.log("Could not check current version, have checked too many times skipping");
+     return;
   }
   const latestVersion = res.data[0].name;
   const pkg = meow('', { importMeta: import.meta }).pkg;

--- a/util/version-checker.js
+++ b/util/version-checker.js
@@ -2,9 +2,13 @@ import axios from 'axios';
 import meow from 'meow';
 
 const checkVersion = async () => {
-  const res = await axios.default(
-    'https://api.github.com/repos/SwapnilSoni1999/spotify-dl/tags'
-  );
+  try {
+    const res = await axios.default(
+      'https://api.github.com/repos/SwapnilSoni1999/spotify-dl/tags'
+    );
+  } catch (_e) {
+     console.log("Could not check current version, have checked too many times skipping");
+  }
   const latestVersion = res.data[0].name;
   const pkg = meow('', { importMeta: import.meta }).pkg;
 


### PR DESCRIPTION
fixes #254 

Looks like checking for the tags to review version runs into rate limiting sometimes, just soft error instead