### PR TITLE
Fix ReferenceError: res is not defined in version-checker.js

### DIFF
--- a/util/version-checker.js
+++ b/util/version-checker.js
@@ -3,25 +3,20 @@ import meow from 'meow';
 
 const checkVersion = async () => {
   try {
-    const res = await axios.default(
-      'https://api.github.com/repos/SwapnilSoni1999/spotify-dl/tags'
-    );
-  } catch (_e) {
-     console.log("Could not check current version, have checked too many times skipping");
-     return;
-  }
-  const latestVersion = res.data[0].name;
-  const pkg = meow('', { importMeta: import.meta }).pkg;
+    const res = await axios.get('https://api.github.com/repos/SwapnilSoni1999/spotify-dl/tags');
+    const latestVersion = res.data[0].name;
+    const pkg = meow('', { importMeta: import.meta }).pkg;
 
-  if (pkg.version !== latestVersion) {
-    console.log(
-      [
-        '\n========Update Available========',
-        'Use npm install -g spotify-dl',
-        'to update the package.',
-        '================================\n',
-      ].join('\n')
-    );
+    if (pkg.version !== latestVersion) {
+      console.log(
+        '\n========Update Available========\n' +
+        'Use npm install -g spotify-dl\n' +
+        'to update the package.\n' +
+        '================================\n'
+      );
+    }
+  } catch (error) {
+    console.log("Could not check current version, have checked too many times, skipping");
   }
 };
 


### PR DESCRIPTION

# Title
Fix ReferenceError: res is not defined in version-checker.js

## Details
This pull request fixes a ReferenceError in the `version-checker.js` file where `res` was not defined before being used. By defining `res` properly and ensuring it is assigned within the try block, we prevent the error and allow the version check to function correctly.

## Testing
Tested locally by running the script to ensure no errors are thrown and the version check completes successfully. Verified that the console output indicates whether an update is available or not.

## Checklist
- [x] Ran eslint/prettier formatting
- [x] Tests are passing (no tests yet)
- [x] Feature is considered complete
