### PR TITLE
Fix 403 error by upgrading the ytdl-core package

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "spotify-web-api-node": "^5.0.0",
     "string-similarity": "^4.0.4",
     "yt-search": "^2.10.3",
-    "@distube/ytdl-core": "^4.14.4"
+    "@distube/ytdl-core": "^4.15.9"
   },
   "xo": {
     "space": true,


### PR DESCRIPTION
<!-- **IMPORTANT: Please do not create a Pull Request without creating an issue first.** -->
<!-- *Any change may need to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.* -->
# Title
Fix 403 error when downloading tracks

## Details
Upgraded the `@distube/ytdl-core` package to version `4.15.9`

## Testing
Works on my machine.

## Checklist
I just modified a package version, tried running all features and everything works as intended.

## Issues this resolves
Fixes `#264`