### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@swapnilsoni1999/spotify-dl",
   "productName": "Spotify Downloader",
-  "version": "1.2.8",
+  "version": "1.3.0",
   "description": "Spotify Songs, Playlist & Album Downloader",
   "main": "app.js",
   "bin": {


### PR DESCRIPTION
Bump to 1.3.0

Fix 403 issue with downloads

Various package updates

BREAKING CHANGES: 
* This Increases the minimum node version to 22